### PR TITLE
Feat plant classifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ models/speech/svm
 models/speech/serab-byols
 models/speech/byols
 models/cache
+models/plant/plant_dense
+models/plant/plant_lstm
+models/plant/plant_mfcc_cnn
 
 # Documentation
 !docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
-# Project
+# Project Data
 data/train/text
 data/train/image
 data/train/speech
+
+data/plant
+data/video
+data/ground_truth
+
 experiments/results
 
 # Models
@@ -28,6 +33,11 @@ docs/*
 !docs/make.bat
 !docs/Makefile
 .idea
+
+# Project Other
+src/utils/faceapi/node_modules/
+src/utils/faceapi/package-lock.json
+src/utils/faceapi/weights/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/data/DESCRIPTION.md
+++ b/data/DESCRIPTION.md
@@ -1,16 +1,18 @@
 # Data Folder Structure
 
 This file describes how you need to setup the data folder for the code to work properly.
-This folder contains two subfolders:
-The train folder is used to store all the data that is used for training the emotion classification models.
-The eval folder contains the custom data that is used for evaluation accross different modalities.
+This folder contains multiple subfolders:
+The train folder is used to store all the data that is used for training the text, voice and face emotion classification models.
+The other folders contain the custom data that is used for evaluation across different modalities.
 <div class="disclaimer" style="background-color: #f5ea92">
    ⚠️&nbsp When using any of these datasets, please remember to cite the corresponding papers! Check the websites for more information.
 </div>
 
 ## Training data
 To download the training datasets required for training certain emotion classification models,
-use the bash scripts provided in the train folder.
+use the bash scripts provided in the train folder.  
+Some of the datasets can not be downloaded automatically because you need to request access to them and they are to be used for research only.
+The following sections will list all the datasets and how you can access them.
 
 ### Text Data
 To download the text datasets, please use the `download_text_data.sh` script in the train folder.
@@ -60,5 +62,10 @@ This will download these datasets:
 3. [Crema D Dataset](https://www.tensorflow.org/datasets/catalog/crema_d):
    1. This dataset is stored in your tfds download folder (usually `/home/$USER/tensorflow-datasets`)
 
-## Eval data
-TODO
+## Evaluation data
+This part of the data has been collected by myself during my time at MIT.  
+It can not be disclosed publicly because of privacy reasons of the subjects of the data stud
+
+### Plant Data
+The plant data should be cut to the experiment duration and then placed in the `plant` subfolder.  
+

--- a/experiments/job_array.sh
+++ b/experiments/job_array.sh
@@ -2,13 +2,13 @@
 
 source /etc/profile
 module load anaconda/2022a
-module load cuda/11.6
+module load cuda/11.3
 
 echo "My task ID: " $LLSUB_RANK
 echo "Number of Tasks: " $LLSUB_SIZE
 
 export PYTHONPATH=.
 export TFHUB_CACHE_DIR="$(pwd)/models/cache"
-python experiments/scripts/byols_parameters.py $LLSUB_RANK $LLSUB_SIZE
+python experiments/scripts/plant_classifiers.py $LLSUB_RANK $LLSUB_SIZE
 
 # Might need to run chmod u+x job_array.sh

--- a/experiments/scripts/plant_classifiers.py
+++ b/experiments/scripts/plant_classifiers.py
@@ -42,8 +42,8 @@ if __name__ == "__main__":
         {"epochs": 50, "patience": 10, "batch_size": 64},
         learning_rate=[0.0003, 0.001],
         lstm_units=[64, 256, 1024],
-        lstm_layers=[1, 2],
-        dropout=[0, 0.2, 0.3],
+        lstm_layers=[1, 2, 3],
+        dropout=[0, 0.2],
         label_mode=["expected", "faceapi"],
         window=[5, 10, 20],
         hop=[5, 10],
@@ -53,6 +53,41 @@ if __name__ == "__main__":
         modality="plant",
         model="plant_lstm",
         train_parameters=lstm_configs,
+    )
+
+    dense_configs = make_dictionaries(
+        {"epochs": 50, "patience": 10, "batch_size": 64},
+        learning_rate=[0.0003, 0.001],
+        dense_units=[1024, 4096],
+        dense_layers=[2, 4],
+        dropout=[0, 0.2],
+        label_mode=["expected", "faceapi"],
+        window=[5, 10, 20],
+        hop=[5, 10],
+        weighted=[False, True],
+    )
+    runner.add_grid_experiments(
+        modality="plant",
+        model="plant_dense",
+        train_parameters=dense_configs,
+    )
+
+    mfcc_configs = make_dictionaries(
+        {"epochs": 50, "patience": 10, "batch_size": 64, "preprocess": False},
+        learning_rate=[0.0003, 0.001],
+        conv_filters=[64, 128],
+        conv_layers=[2, 3],
+        conv_kernel_size=[3, 5, 7],
+        dropout=[0, 0.2],
+        label_mode=["expected", "faceapi"],
+        window=[5, 10, 20],
+        hop=[5, 10],
+        weighted=[False, True],
+    )
+    runner.add_grid_experiments(
+        modality="plant",
+        model="plant_mfcc_cnn",
+        train_parameters=mfcc_configs,
     )
 
     my_experiments = list(range(len(runner.experiments)))[

--- a/experiments/scripts/plant_classifiers.py
+++ b/experiments/scripts/plant_classifiers.py
@@ -39,15 +39,15 @@ if __name__ == "__main__":
     runner = CrossValidationExperimentRunner("plant_parameters")
 
     lstm_configs = make_dictionaries(
-        {"epochs": 50, "patience": 10, "batch_size": 8},
+        {"epochs": 1, "patience": 10, "batch_size": 8},
         learning_rate=[0.0003, 0.001],
         lstm_units=[64, 256, 1024],
         lstm_layers=[1, 2],
-        dropout=[0.2, 0.3],
+        dropout=[0, 0.2, 0.3],
         label_mode=["expected", "faceapi"],
         window=[5, 10, 20],
         hop=[5, 10],
-        weighted=[True, False],
+        weighted=[False, True],
     )
     runner.add_grid_experiments(
         modality="plant",

--- a/experiments/scripts/plant_classifiers.py
+++ b/experiments/scripts/plant_classifiers.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     runner = CrossValidationExperimentRunner("plant_parameters")
 
     lstm_configs = make_dictionaries(
-        {"epochs": 1, "patience": 10, "batch_size": 8},
+        {"epochs": 1, "patience": 10, "batch_size": 64},
         learning_rate=[0.0003, 0.001],
         lstm_units=[64, 256, 1024],
         lstm_layers=[1, 2],

--- a/experiments/scripts/plant_classifiers.py
+++ b/experiments/scripts/plant_classifiers.py
@@ -1,0 +1,67 @@
+"""This script runs some plant classifier configs for testing"""
+import sys
+
+import tensorflow as tf
+
+from src.experiment.cv_experiment import CrossValidationExperimentRunner
+from src.experiment.experiment import make_dictionaries
+
+try:
+    my_task_id = int(sys.argv[1])
+    num_tasks = int(sys.argv[2])
+except IndexError:
+    my_task_id = 0
+    num_tasks = 1
+
+
+def setup_gpu():
+    physical_devices = tf.config.list_physical_devices("GPU")
+    if len(physical_devices) == 2:
+        if my_task_id % 2 == 0:
+            tf.config.set_visible_devices(physical_devices[1:], "GPU")
+            tf.config.experimental.set_memory_growth(
+                physical_devices[1], False
+            )
+            return 1
+
+        else:
+            tf.config.set_visible_devices(physical_devices[:1], "GPU")
+            tf.config.experimental.set_memory_growth(
+                physical_devices[0], False
+            )
+            return 0
+
+
+if __name__ == "__main__":
+
+    which_gpu = setup_gpu()
+    # Start grid search with balanced data here
+    runner = CrossValidationExperimentRunner("plant_parameters")
+
+    lstm_configs = make_dictionaries(
+        {"epochs": 50, "patience": 10, "batch_size": 8},
+        learning_rate=[0.0003, 0.001],
+        lstm_units=[64, 256, 1024],
+        lstm_layers=[1, 2],
+        dropout=[0.2, 0.3],
+        label_mode=["expected", "faceapi"],
+        window=[5, 10, 20],
+        hop=[5, 10],
+        weighted=[True, False],
+    )
+    runner.add_grid_experiments(
+        modality="plant",
+        model="plant_lstm",
+        train_parameters=lstm_configs,
+    )
+
+    my_experiments = list(range(len(runner.experiments)))[
+        my_task_id::num_tasks
+    ]
+
+    print(
+        f"Running {len(my_experiments)} out of "
+        f"{len(runner.experiments)} experiments."
+    )
+
+    runner.run_all(indices=my_experiments)

--- a/experiments/scripts/plant_classifiers.py
+++ b/experiments/scripts/plant_classifiers.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     runner = CrossValidationExperimentRunner("plant_parameters")
 
     lstm_configs = make_dictionaries(
-        {"epochs": 1, "patience": 10, "batch_size": 64},
+        {"epochs": 50, "patience": 10, "batch_size": 64},
         learning_rate=[0.0003, 0.001],
         lstm_units=[64, 256, 1024],
         lstm_layers=[1, 2],

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ seaborn
 transformers
 hmmlearn
 librosa
+requests
+moviepy

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ datashader
 matplotlib
 bokeh
 holoviews
+scikit-learn
 scikit-image
 colorcet
 alive-progress

--- a/src/classification/classifier_factory.py
+++ b/src/classification/classifier_factory.py
@@ -7,7 +7,11 @@ from src.classification.image import (
     MultiTaskEfficientNetB2Classifier,
     VGG16Classifier,
 )
-from src.classification.plant import PlantLSTMClassifier
+from src.classification.plant import (
+    PlantDenseClassifier,
+    PlantLSTMClassifier,
+    PlantMFCCCNNClassifier,
+)
 from src.classification.speech import (
     BYOLSClassifier,
     GMMClassifier,
@@ -149,5 +153,9 @@ class PlantClassifierFactory:
         """
         if model == "plant_lstm":
             return PlantLSTMClassifier(parameters)
+        elif model == "plant_dense":
+            return PlantDenseClassifier(parameters)
+        elif model == "plant_mfcc_cnn":
+            return PlantMFCCCNNClassifier(parameters)
         else:
             raise ValueError(f"Plant model {model} not implemented!")

--- a/src/classification/classifier_factory.py
+++ b/src/classification/classifier_factory.py
@@ -7,6 +7,7 @@ from src.classification.image import (
     MultiTaskEfficientNetB2Classifier,
     VGG16Classifier,
 )
+from src.classification.plant import PlantLSTMClassifier
 from src.classification.speech import (
     BYOLSClassifier,
     GMMClassifier,
@@ -46,6 +47,8 @@ class ClassifierFactory:
             return ImageClassifierFactory.get(model, parameters)
         elif modality == "speech":
             return SpeechClassifierFactory.get(model, parameters)
+        elif modality == "plant":
+            return PlantClassifierFactory.get(model, parameters)
         else:
             raise ValueError(f"Modality {modality} not supported!")
 
@@ -128,3 +131,23 @@ class SpeechClassifierFactory:
             return BYOLSClassifier(parameters)
         else:
             raise ValueError(f"Speech model {model} not implemented!")
+
+
+class PlantClassifierFactory:
+    """
+    Factory class that generates plant emotion classifiers
+    """
+
+    @staticmethod
+    def get(model: str, parameters: Dict = None) -> EmotionClassifier:
+        """
+        Method that returns an instance of a plant emotion classifier
+
+        :param model: The name of the plant model
+        :param parameters: The parameters for the plant model
+        :return: The constructed plant classifier
+        """
+        if model == "plant_lstm":
+            return PlantLSTMClassifier(parameters)
+        else:
+            raise ValueError(f"Plant model {model} not implemented!")

--- a/src/classification/image/cross_attention_classifier.py
+++ b/src/classification/image/cross_attention_classifier.py
@@ -17,6 +17,7 @@ from src.classification.image.image_emotion_classifier import (
     ImageEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class DAN(nn.Module):
@@ -565,4 +566,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/image/efficientnet_classifier.py
+++ b/src/classification/image/efficientnet_classifier.py
@@ -10,6 +10,7 @@ from src.classification.image.image_emotion_classifier import (
     ImageEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class MultiTaskEfficientNetB2Classifier(ImageEmotionClassifier):
@@ -158,4 +159,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/image/vgg16_classifier.py
+++ b/src/classification/image/vgg16_classifier.py
@@ -10,6 +10,7 @@ from src.classification.image.image_emotion_classifier import (
     ImageEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class VGG16Classifier(ImageEmotionClassifier):
@@ -180,4 +181,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/plant/__init__.py
+++ b/src/classification/plant/__init__.py
@@ -1,4 +1,6 @@
 """Package for plant sensor emotion classifiers"""
 
+from .dense_classifier import PlantDenseClassifier  # noqa: F401
 from .lstm_classifier import PlantLSTMClassifier  # noqa: F401
+from .mfcc_cnn_classifier import PlantMFCCCNNClassifier  # noqa: F401
 from .plant_emotion_classifier import PlantEmotionClassifier  # noqa: F401

--- a/src/classification/plant/__init__.py
+++ b/src/classification/plant/__init__.py
@@ -1,0 +1,4 @@
+"""Package for plant sensor emotion classifiers"""
+
+from .lstm_classifier import PlantLSTMClassifier  # noqa: F401
+from .plant_emotion_classifier import PlantEmotionClassifier  # noqa: F401

--- a/src/classification/plant/dense_classifier.py
+++ b/src/classification/plant/dense_classifier.py
@@ -1,0 +1,64 @@
+""" This file implements a Fully Connected classifier for the plant data. """
+import os
+import sys
+from typing import Dict
+
+import tensorflow as tf
+
+from src.classification.plant.nn_classifier import PlantNNBaseClassifier
+from src.data.data_reader import Set
+from src.utils.metrics import accuracy, per_class_accuracy
+
+
+class PlantDenseClassifier(PlantNNBaseClassifier):
+    def __init__(self, parameters: Dict = None):
+        """
+        Initialize the Plant-Dense emotion classifier
+
+        :param name: The name for the classifier
+        :param parameters: Some configuration parameters for the classifier
+        """
+        super().__init__("plant_dense", parameters)
+
+    def initialize_model(self, parameters: Dict) -> None:
+        """
+        Initializes a new and pretrained version of the Plant-Dense model
+        """
+        dense_units = parameters.get("dense_units", 512)
+        dropout = parameters.get("dropout", 0.2)
+        input_size = self.data_reader.get_input_shape(parameters)[0]
+        hidden_layers = parameters.get("hidden_layers", 2)
+        input = tf.keras.layers.Input(
+            shape=(input_size,), dtype=tf.float32, name="raw"
+        )
+        hidden = tf.keras.layers.Dense(dense_units)(input)
+        hidden = tf.keras.layers.Dropout(dropout)(hidden)
+        for layer_id in range(hidden_layers - 1):
+            hidden = tf.keras.layers.Dense(dense_units)(hidden)
+            hidden = tf.keras.layers.Dropout(dropout)(hidden)
+        out = tf.keras.layers.Dense(7, activation="softmax")(hidden)
+        self.model = tf.keras.Model(input, out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    classifier = PlantDenseClassifier()
+    parameters = {
+        "epochs": 10,
+        "patience": 5,
+        "learning_rate": 0.001,
+        "dense_units": 1024,
+        "hidden_layers": 2,
+        "dropout": 0.2,
+        "batch_size": 32,
+    }
+    if not os.path.exists("models/plant/plant_dense") or "train" in sys.argv:
+        classifier.train(parameters)
+        classifier.save()
+
+    classifier.load(parameters)
+    emotions = classifier.classify(parameters)
+    labels = classifier.data_reader.get_labels(Set.TEST)
+    print(f"Labels Shape: {labels.shape}")
+    print(f"Emotions Shape: {emotions.shape}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")
+    print(f"Per Class Accuracy: {per_class_accuracy(labels, emotions)}")

--- a/src/classification/plant/lstm_classifier.py
+++ b/src/classification/plant/lstm_classifier.py
@@ -37,10 +37,12 @@ class PlantLSTMClassifier(PlantEmotionClassifier):
             shape=(input_size, 1), dtype=tf.float32, name="raw"
         )
         if lstm_layers == 2:
-            input = tf.keras.layers.LSTM(lstm_units, return_sequences=True)(
-                input
-            )
-        out = tf.keras.layers.LSTM(lstm_units)(input)
+            input = tf.keras.layers.Bidirectional(
+                tf.keras.layers.LSTM(lstm_units, return_sequences=True)
+            )(input)
+        out = tf.keras.layers.Bidirectional(tf.keras.layers.LSTM(lstm_units))(
+            input
+        )
         out = tf.keras.layers.Dropout(dropout)(out)
         out = tf.keras.layers.Dense(1024, activation="relu")(out)
         out = tf.keras.layers.Dense(512, activation="relu")(out)

--- a/src/classification/plant/lstm_classifier.py
+++ b/src/classification/plant/lstm_classifier.py
@@ -1,0 +1,139 @@
+""" This file implements an LSTM based classifier for the plant data. """
+import os
+import sys
+from typing import Dict
+
+import numpy as np
+import tensorflow as tf
+
+from src.classification.plant.plant_emotion_classifier import (
+    PlantEmotionClassifier,
+)
+from src.data.data_reader import Set
+
+
+class PlantLSTMClassifier(PlantEmotionClassifier):
+    def __init__(self, parameters: Dict = None):
+        """
+        Initialize the Plant-LSTM emotion classifier
+
+        :param name: The name for the classifier
+        :param parameters: Some configuration parameters for the classifier
+        """
+        super().__init__("plant_lstm", parameters)
+        tf.get_logger().setLevel("ERROR")
+        self.model = None
+
+    def initialize_model(self, parameters: Dict) -> None:
+        """
+        Initializes a new and pretrained version of the Plant-LSTM model
+        """
+        lstm_units = parameters.get("lstm_units", 512)
+        dropout = parameters.get("dropout", 0.2)
+        window = parameters.get("window", 10)
+        input = tf.keras.layers.Input(
+            shape=(window * 10000, 1), dtype=tf.float32, name="raw"
+        )
+        out = tf.keras.layers.LSTM(lstm_units)(input)
+        out = tf.keras.layers.Dropout(dropout)(out)
+        out = tf.keras.layers.Dense(1024, activation="relu")(out)
+        out = tf.keras.layers.Dense(512, activation="relu")(out)
+        out = tf.keras.layers.Dense(7, activation="softmax")(out)
+        self.model = tf.keras.Model(input, out)
+
+    def train(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Training method for Plant-LSTM model
+
+        :param parameters: Parameter dictionary used for training
+        :param kwargs: Additional kwargs parameters
+        """
+        parameters = self.init_parameters(parameters, **kwargs)
+        epochs = parameters.get("epochs", 20)
+
+        if not self.model:
+            self.initialize_model(parameters)
+        self.prepare_training(parameters)
+        self.model.compile(
+            optimizer=self.optimizer, loss=self.loss, metrics=self.metrics
+        )
+        self.prepare_data(parameters)
+
+        _ = self.model.fit(
+            x=self.train_data,
+            validation_data=self.val_data,
+            epochs=epochs,
+            callbacks=[self.callback],
+            class_weight=self.class_weights,
+        )
+        self.is_trained = True
+
+    def load(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Loading method that loads a previously trained model from disk.
+
+        :param parameters: Parameters required for loading the model
+        :param kwargs: Additional kwargs parameters
+        """
+        parameters = self.init_parameters(parameters, **kwargs)
+        save_path = parameters.get("save_path", "models/plant/plant_lstm")
+        self.model = tf.keras.models.load_model(save_path)
+
+    def save(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Saving method that saves a previously trained model on disk.
+
+        :param parameters: Parameters required for storing the model
+        :param kwargs: Additional kwargs parameters
+        """
+        if not self.is_trained:
+            raise RuntimeError(
+                "Model needs to be trained in order to save it!"
+            )
+        parameters = self.init_parameters(parameters, **kwargs)
+        save_path = parameters.get("save_path", "models/plant/plant_lstm")
+        self.model.save(save_path, include_optimizer=False)
+
+    def classify(self, parameters: Dict = None, **kwargs) -> np.array:
+        """
+        Classification method used to classify emotions from speech
+
+        :param parameters: Parameter dictionary used for classification
+        :param kwargs: Additional kwargs parameters
+        :return: An array with predicted emotion indices
+        """
+        parameters = self.init_parameters(parameters, **kwargs)
+        which_set = parameters.get("which_set", Set.TEST)
+        batch_size = parameters.get("batch_size", 64)
+        dataset = self.data_reader.get_emotion_data(
+            self.emotions, which_set, batch_size, parameters
+        )
+
+        if not self.model:
+            raise RuntimeError(
+                "Please load or train the model before inference!"
+            )
+        results = self.model.predict(dataset)
+        return np.argmax(results, axis=1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    classifier = PlantLSTMClassifier()
+    parameters = {
+        "epochs": 10,
+        "patience": 5,
+        "learning_rate": 0.001,
+        "lstm_units": 128,
+        "dropout": 0.2,
+        "batch_size": 8,
+    }
+    if not os.path.exists("models/plant/plant_lstm") or "train" in sys.argv:
+        classifier.train(parameters)
+        classifier.save()
+
+    classifier.load(parameters)
+    emotions = classifier.classify(parameters)
+    labels = classifier.data_reader.get_labels(Set.TEST)
+    print(f"Labels Shape: {labels.shape}")
+    print(f"Emotions Shape: {emotions.shape}")
+    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")

--- a/src/classification/plant/lstm_classifier.py
+++ b/src/classification/plant/lstm_classifier.py
@@ -40,6 +40,7 @@ class PlantLSTMClassifier(PlantEmotionClassifier):
         out = tf.keras.layers.Dense(512, activation="relu")(out)
         out = tf.keras.layers.Dense(7, activation="softmax")(out)
         self.model = tf.keras.Model(input, out)
+        print(self.model.summary())
 
     def train(self, parameters: Dict = None, **kwargs) -> None:
         """
@@ -125,7 +126,7 @@ if __name__ == "__main__":  # pragma: no cover
         "learning_rate": 0.001,
         "lstm_units": 128,
         "dropout": 0.2,
-        "batch_size": 8,
+        "batch_size": 32,
     }
     if not os.path.exists("models/plant/plant_lstm") or "train" in sys.argv:
         classifier.train(parameters)

--- a/src/classification/plant/lstm_classifier.py
+++ b/src/classification/plant/lstm_classifier.py
@@ -3,17 +3,14 @@ import os
 import sys
 from typing import Dict
 
-import numpy as np
 import tensorflow as tf
 
-from src.classification.plant.plant_emotion_classifier import (
-    PlantEmotionClassifier,
-)
+from src.classification.plant.nn_classifier import PlantNNBaseClassifier
 from src.data.data_reader import Set
 from src.utils.metrics import accuracy, per_class_accuracy
 
 
-class PlantLSTMClassifier(PlantEmotionClassifier):
+class PlantLSTMClassifier(PlantNNBaseClassifier):
     def __init__(self, parameters: Dict = None):
         """
         Initialize the Plant-LSTM emotion classifier
@@ -22,8 +19,6 @@ class PlantLSTMClassifier(PlantEmotionClassifier):
         :param parameters: Some configuration parameters for the classifier
         """
         super().__init__("plant_lstm", parameters)
-        tf.get_logger().setLevel("ERROR")
-        self.model = None
 
     def initialize_model(self, parameters: Dict) -> None:
         """
@@ -36,93 +31,28 @@ class PlantLSTMClassifier(PlantEmotionClassifier):
         input = tf.keras.layers.Input(
             shape=(input_size, 1), dtype=tf.float32, name="raw"
         )
-        if lstm_layers == 2:
-            input = tf.keras.layers.Bidirectional(
+        if lstm_layers >= 2:
+            out = tf.keras.layers.Bidirectional(
                 tf.keras.layers.LSTM(lstm_units, return_sequences=True)
             )(input)
-        out = tf.keras.layers.Bidirectional(tf.keras.layers.LSTM(lstm_units))(
-            input
-        )
+            for i in range(lstm_layers - 2):
+                out = tf.keras.layers.Bidirectional(
+                    tf.keras.layers.LSTM(lstm_units, return_sequences=True)
+                )(out)
+            out = tf.keras.layers.Bidirectional(
+                tf.keras.layers.LSTM(lstm_units)
+            )(out)
+        else:
+            out = tf.keras.layers.Bidirectional(
+                tf.keras.layers.LSTM(lstm_units)
+            )(input)
         out = tf.keras.layers.Dropout(dropout)(out)
         out = tf.keras.layers.Dense(1024, activation="relu")(out)
+        out = tf.keras.layers.Dropout(dropout)(out)
         out = tf.keras.layers.Dense(512, activation="relu")(out)
+        out = tf.keras.layers.Dropout(dropout)(out)
         out = tf.keras.layers.Dense(7, activation="softmax")(out)
         self.model = tf.keras.Model(input, out)
-
-    def train(self, parameters: Dict = None, **kwargs) -> None:
-        """
-        Training method for Plant-LSTM model
-
-        :param parameters: Parameter dictionary used for training
-        :param kwargs: Additional kwargs parameters
-        """
-        parameters = self.init_parameters(parameters, **kwargs)
-        epochs = parameters.get("epochs", 20)
-
-        if not self.model:
-            self.initialize_model(parameters)
-        self.prepare_training(parameters)
-        self.model.compile(
-            optimizer=self.optimizer, loss=self.loss, metrics=self.metrics
-        )
-        self.prepare_data(parameters)
-
-        _ = self.model.fit(
-            x=self.train_data,
-            validation_data=self.val_data,
-            epochs=epochs,
-            callbacks=[self.callback],
-            class_weight=self.class_weights,
-        )
-        self.is_trained = True
-
-    def load(self, parameters: Dict = None, **kwargs) -> None:
-        """
-        Loading method that loads a previously trained model from disk.
-
-        :param parameters: Parameters required for loading the model
-        :param kwargs: Additional kwargs parameters
-        """
-        parameters = self.init_parameters(parameters, **kwargs)
-        save_path = parameters.get("save_path", "models/plant/plant_lstm")
-        self.model = tf.keras.models.load_model(save_path)
-
-    def save(self, parameters: Dict = None, **kwargs) -> None:
-        """
-        Saving method that saves a previously trained model on disk.
-
-        :param parameters: Parameters required for storing the model
-        :param kwargs: Additional kwargs parameters
-        """
-        if not self.is_trained:
-            raise RuntimeError(
-                "Model needs to be trained in order to save it!"
-            )
-        parameters = self.init_parameters(parameters, **kwargs)
-        save_path = parameters.get("save_path", "models/plant/plant_lstm")
-        self.model.save(save_path, include_optimizer=False)
-
-    def classify(self, parameters: Dict = None, **kwargs) -> np.array:
-        """
-        Classification method used to classify emotions from speech
-
-        :param parameters: Parameter dictionary used for classification
-        :param kwargs: Additional kwargs parameters
-        :return: An array with predicted emotion indices
-        """
-        parameters = self.init_parameters(parameters, **kwargs)
-        which_set = parameters.get("which_set", Set.TEST)
-        batch_size = parameters.get("batch_size", 64)
-        dataset = self.data_reader.get_emotion_data(
-            self.emotions, which_set, batch_size, parameters
-        )
-
-        if not self.model:
-            raise RuntimeError(
-                "Please load or train the model before inference!"
-            )
-        results = self.model.predict(dataset)
-        return np.argmax(results, axis=1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/classification/plant/mfcc_cnn_classifier.py
+++ b/src/classification/plant/mfcc_cnn_classifier.py
@@ -1,0 +1,93 @@
+""" This file implements a CNN classifier for the MFCC features derived
+from the plant data. """
+import os
+import sys
+from typing import Dict
+
+import tensorflow as tf
+
+from src.classification.plant.nn_classifier import PlantNNBaseClassifier
+from src.data.data_reader import Set
+from src.utils.metrics import accuracy, per_class_accuracy
+
+
+class PlantMFCCCNNClassifier(PlantNNBaseClassifier):
+    def __init__(self, parameters: Dict = None):
+        """
+        Initialize the Plant-MFCC-CNN emotion classifier
+
+        :param name: The name for the classifier
+        :param parameters: Some configuration parameters for the classifier
+        """
+        super().__init__("plant_mfcc_cnn", parameters)
+
+    def initialize_model(self, parameters: Dict) -> None:
+        """
+        Initializes a new and pretrained version of the Plant-MFCC-CNN model
+        """
+        dropout = parameters.get("dropout", 0.2)
+        conv_layers = parameters.get("conv_layers", 3)
+        conv_filters = parameters.get("conv_filters", 64)
+        conv_kernel_size = parameters.get("conv_kernel_size", 7)
+        input_size = self.data_reader.get_input_shape(parameters)[0]
+        input = tf.keras.layers.Input(
+            shape=(input_size,), dtype=tf.float32, name="raw"
+        )
+        mfcc = self.compute_mfccs(input)
+        hidden = tf.expand_dims(mfcc, 3)
+        for i in range(conv_layers):
+            hidden = tf.keras.layers.Conv2D(
+                conv_filters, kernel_size=conv_kernel_size, padding="same"
+            )(hidden)
+            hidden = tf.keras.layers.MaxPooling2D()(hidden)
+
+        hidden = tf.keras.layers.Flatten()(hidden)
+        hidden = tf.keras.layers.Dense(1024)(hidden)
+        hidden = tf.keras.layers.Dropout(dropout)(hidden)
+        hidden = tf.keras.layers.Dense(1024)(hidden)
+        hidden = tf.keras.layers.Dropout(dropout)(hidden)
+        out = tf.keras.layers.Dense(7, activation="softmax")(hidden)
+        self.model = tf.keras.Model(input, out)
+        print(self.model.summary())
+
+    @staticmethod
+    def init_parameters(parameters: Dict = None, **kwargs) -> Dict:
+        """
+        Function that merges the parameters and kwargs
+
+        :param parameters: Parameter dictionary
+        :param kwargs: Additional parameters in kwargs
+        :return: Combined dictionary with parameters
+        """
+        parameters = parameters or {}
+        parameters.update(kwargs)
+        parameters["preprocess"] = False  # Crucial step otherwise MFCC broken
+        return parameters
+
+
+if __name__ == "__main__":  # pragma: no cover
+    classifier = PlantMFCCCNNClassifier()
+    parameters = {
+        "epochs": 50,
+        "patience": 10,
+        "batch_size": 64,
+        "conv_filters": 64,
+        "conv_layers": 2,
+        "conv_kernel_size": 3,
+        "window": 5,
+        "hop": 5,
+    }
+    if (
+        not os.path.exists("models/plant/plant_mfcc_cnn")
+        or "train" in sys.argv
+    ):
+        classifier.train(parameters)
+        classifier.save()
+
+    classifier.load(parameters)
+    emotions = classifier.classify(parameters)
+    labels = classifier.data_reader.get_labels(Set.TEST)
+    print(f"Labels Shape: {labels.shape}")
+    print(f"Emotions Shape: {emotions.shape}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")
+    print(f"Per Class Accuracy: {per_class_accuracy(labels, emotions)}")

--- a/src/classification/plant/nn_classifier.py
+++ b/src/classification/plant/nn_classifier.py
@@ -1,0 +1,111 @@
+""" This file implements an LSTM based classifier for the plant data. """
+
+from abc import abstractmethod
+from typing import Dict
+
+import numpy as np
+import tensorflow as tf
+
+from src.classification.plant.plant_emotion_classifier import (
+    PlantEmotionClassifier,
+)
+from src.data.data_reader import Set
+
+
+class PlantNNBaseClassifier(PlantEmotionClassifier):
+    def __init__(self, name: str, parameters: Dict = None):
+        """
+        Initialize the Plant-LSTM emotion classifier
+
+        :param name: The name for the classifier
+        :param parameters: Some configuration parameters for the classifier
+        """
+        super().__init__(name, parameters)
+        tf.get_logger().setLevel("ERROR")
+        self.model = None
+
+    @abstractmethod
+    def initialize_model(self, parameters: Dict) -> None:
+        """
+        Base class that creates self.model, a tf Model instance
+        """
+        raise NotImplementedError()
+
+    def train(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Training method for Plant-LSTM model
+
+        :param parameters: Parameter dictionary used for training
+        :param kwargs: Additional kwargs parameters
+        """
+        parameters = self.init_parameters(parameters, **kwargs)
+        epochs = parameters.get("epochs", 20)
+
+        if not self.model:
+            self.initialize_model(parameters)
+        self.prepare_training(parameters)
+        self.model.compile(
+            optimizer=self.optimizer, loss=self.loss, metrics=self.metrics
+        )
+        self.prepare_data(parameters)
+
+        _ = self.model.fit(
+            x=self.train_data,
+            validation_data=self.val_data,
+            epochs=epochs,
+            callbacks=[self.callback],
+            class_weight=self.class_weights,
+        )
+        self.is_trained = True
+
+    def load(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Loading method that loads a previously trained model from disk.
+
+        :param parameters: Parameters required for loading the model
+        :param kwargs: Additional kwargs parameters
+        """
+        parameters = self.init_parameters(parameters, **kwargs)
+        save_path = parameters.get("save_path", f"models/plant/{self.name}")
+        self.model = tf.keras.models.load_model(save_path)
+
+    def save(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Saving method that saves a previously trained model on disk.
+
+        :param parameters: Parameters required for storing the model
+        :param kwargs: Additional kwargs parameters
+        """
+        if not self.is_trained:
+            raise RuntimeError(
+                "Model needs to be trained in order to save it!"
+            )
+        parameters = self.init_parameters(parameters, **kwargs)
+        save_path = parameters.get("save_path", f"models/plant/{self.name}")
+        self.model.save(save_path, include_optimizer=False)
+
+    def classify(self, parameters: Dict = None, **kwargs) -> np.array:
+        """
+        Classification method used to classify emotions from speech
+
+        :param parameters: Parameter dictionary used for classification
+        :param kwargs: Additional kwargs parameters
+        :return: An array with predicted emotion indices
+        """
+        parameters = self.init_parameters(parameters, **kwargs)
+        which_set = parameters.get("which_set", Set.TEST)
+        batch_size = parameters.get("batch_size", 64)
+        dataset = self.data_reader.get_emotion_data(
+            self.emotions, which_set, batch_size, parameters
+        )
+
+        if not self.model:
+            raise RuntimeError(
+                "Please load or train the model before inference!"
+            )
+        results = self.model.predict(dataset)
+        return np.argmax(results, axis=1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    classifier = PlantNNBaseClassifier("base")  # Does not work.

--- a/src/classification/plant/plant_emotion_classifier.py
+++ b/src/classification/plant/plant_emotion_classifier.py
@@ -119,7 +119,7 @@ class PlantEmotionClassifier(EmotionClassifier):
 
         # A 1024-point STFT with frames of 64 ms and 75% overlap.
         stfts = tf.signal.stft(
-            audio_tensor, frame_length=1000, frame_step=250, fft_length=1000
+            audio_tensor, frame_length=2500, frame_step=1250, fft_length=2500
         )
         spectrograms = tf.abs(stfts)
 
@@ -148,7 +148,7 @@ class PlantEmotionClassifier(EmotionClassifier):
         # Compute MFCCs from log_mel_spectrograms and take the first 40.
         mfccs = tf.signal.mfccs_from_log_mel_spectrograms(
             log_mel_spectrograms
-        )[..., :40]
+        )[..., :20]
 
         return mfccs
 
@@ -158,6 +158,8 @@ if __name__ == "__main__":  # pragma: no cover
 
     dr = PlantExperimentDataReader()
 
-    for speech, labels in dr.get_seven_emotion_data(Set.TEST).take(1):
+    for speech, labels in dr.get_seven_emotion_data(
+        Set.TEST, parameters={"preprocess": False}
+    ).take(1):
         mfcc = PlantEmotionClassifier.compute_mfccs(speech)
         print(mfcc.shape)

--- a/src/classification/plant/plant_emotion_classifier.py
+++ b/src/classification/plant/plant_emotion_classifier.py
@@ -1,0 +1,163 @@
+""" Base class for all plant emotion classifiers """
+
+from abc import abstractmethod
+from typing import Dict
+
+import numpy as np
+import tensorflow as tf
+
+from src.classification import EmotionClassifier
+from src.data.data_reader import Set
+
+
+class PlantEmotionClassifier(EmotionClassifier):
+    """
+    Base class for all plant emotion classifiers. Contains common functions
+    that concerns all plant classifiers.
+    """
+
+    def __init__(self, name: str = "plant", parameters: Dict = None):
+        """
+        Initialize the plant emotion classifier
+
+        :param name: The name for the classifier
+        :param parameters: Some configuration parameters for the classifier
+        """
+        super().__init__(name, "plant", parameters)
+        parameters = parameters or {}
+        self.callback = None
+        self.optimizer = None
+        self.loss = None
+        self.metrics = None
+        self.train_data = None
+        self.val_data = None
+        self.class_weights = None
+
+    @abstractmethod
+    def train(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Virtual training method for interfacing
+
+        :param parameters: Parameter dictionary used for training
+        :param kwargs: Additional kwargs parameters
+        """
+        raise NotImplementedError("Abstract class")  # pragma: no cover
+
+    @abstractmethod
+    def load(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Loading method that loads a previously trained model from disk.
+
+        :param parameters: Parameters required for loading the model
+        :param kwargs: Additional kwargs parameters
+        """
+        raise NotImplementedError("Abstract class")  # pragma: no cover
+
+    @abstractmethod
+    def save(self, parameters: Dict = None, **kwargs) -> None:
+        """
+        Saving method that saves a previously trained model on disk.
+
+        :param parameters: Parameters required for storing the model
+        :param kwargs: Additional kwargs parameters
+        """
+        raise NotImplementedError("Abstract class")  # pragma: no cover
+
+    @abstractmethod
+    def classify(self, parameters: Dict = None, **kwargs) -> np.array:
+        """
+        The virtual classification method for interfacing
+
+        :param parameters: Parameter dictionary used for classification
+        :param kwargs: Additional kwargs parameters
+        :return: An array with predicted emotion indices
+        """
+        raise NotImplementedError("Abstract class")  # pragma: no cover
+
+    def prepare_training(self, parameters: Dict) -> None:
+        """
+        Function that prepares the training by initializing optimizer,
+        loss, metrics and callbacks for training.
+
+        :param parameters: Training parameters
+        """
+        learning_rate = parameters.get("learning_rate", 0.001)
+        patience = parameters.get("patience", 5)
+
+        self.callback = tf.keras.callbacks.EarlyStopping(
+            monitor="val_loss", patience=patience, restore_best_weights=True
+        )
+        self.optimizer = tf.keras.optimizers.Adam(learning_rate=learning_rate)
+        self.metrics = [tf.metrics.CategoricalAccuracy()]
+        self.loss = tf.keras.losses.CategoricalCrossentropy()
+
+    def prepare_data(self, parameters: Dict) -> None:
+        """
+        Function that prepares speech datasets for training and stores them
+        inside the class.
+
+        :param parameters: Parameter dictionary that contains important params.
+            including: which_set, batch_size, weighted
+        """
+        which_set = parameters.get("which_set", Set.TRAIN)
+        batch_size = parameters.get("batch_size", 64)
+        weighted = parameters.get("weighted", False)
+
+        self.train_data = self.data_reader.get_emotion_data(
+            self.emotions, which_set, batch_size, parameters
+        )
+        self.val_data = self.data_reader.get_emotion_data(
+            self.emotions, Set.VAL, batch_size, parameters
+        )
+        if weighted:
+            self.class_weights = self.get_class_weights(which_set, parameters)
+        else:
+            self.class_weights = None
+
+    @staticmethod
+    def compute_mfccs(audio_tensor: tf.Tensor) -> tf.Tensor:
+
+        # A 1024-point STFT with frames of 64 ms and 75% overlap.
+        stfts = tf.signal.stft(
+            audio_tensor, frame_length=1000, frame_step=250, fft_length=1000
+        )
+        spectrograms = tf.abs(stfts)
+
+        # Warp the linear scale spectrograms into the mel-scale.
+        num_spectrogram_bins = stfts.shape[-1]
+        lower_edge_hertz, upper_edge_hertz, num_mel_bins = 0.0, 100.0, 80
+        linear_to_mel_weight_matrix = tf.signal.linear_to_mel_weight_matrix(
+            num_mel_bins,
+            num_spectrogram_bins,
+            10000,
+            lower_edge_hertz,
+            upper_edge_hertz,
+        )
+        mel_spectrograms = tf.tensordot(
+            spectrograms, linear_to_mel_weight_matrix, 1
+        )
+        mel_spectrograms.set_shape(
+            spectrograms.shape[:-1].concatenate(
+                linear_to_mel_weight_matrix.shape[-1:]
+            )
+        )
+
+        # Compute a stabilized log to get log-magnitude mel-scale spectrograms.
+        log_mel_spectrograms = tf.math.log(mel_spectrograms + 1e-6)
+
+        # Compute MFCCs from log_mel_spectrograms and take the first 40.
+        mfccs = tf.signal.mfccs_from_log_mel_spectrograms(
+            log_mel_spectrograms
+        )[..., :40]
+
+        return mfccs
+
+
+if __name__ == "__main__":  # pragma: no cover
+    from src.data.plant_exp_reader import PlantExperimentDataReader
+
+    dr = PlantExperimentDataReader()
+
+    for speech, labels in dr.get_seven_emotion_data(Set.TEST).take(1):
+        mfcc = PlantEmotionClassifier.compute_mfccs(speech)
+        print(mfcc.shape)

--- a/src/classification/speech/byols_classifier.py
+++ b/src/classification/speech/byols_classifier.py
@@ -14,6 +14,7 @@ from src.classification.speech.speech_emotion_classifier import (
     SpeechEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class BYOLSModel(nn.Module):
@@ -323,4 +324,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/speech/gmm_classifier.py
+++ b/src/classification/speech/gmm_classifier.py
@@ -13,6 +13,7 @@ from src.classification.speech.speech_emotion_classifier import (
 )
 from src.data.classwise_speech_data_reader import ClasswiseSpeechDataReader
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 CLASS_NAMES = [
     "angry",
@@ -168,4 +169,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/speech/hmm_classifier.py
+++ b/src/classification/speech/hmm_classifier.py
@@ -13,6 +13,7 @@ from src.classification.speech.speech_emotion_classifier import (
 )
 from src.data.classwise_speech_data_reader import ClasswiseSpeechDataReader
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 CLASS_NAMES = [
     "angry",
@@ -168,4 +169,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/speech/hubert_classifier.py
+++ b/src/classification/speech/hubert_classifier.py
@@ -14,6 +14,7 @@ from src.classification.speech.speech_emotion_classifier import (
     SpeechEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class FinetuningHuBERTModel(nn.Module):
@@ -301,4 +302,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST, {"dataset": "all"})
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/speech/mfcc_lstm_classifier.py
+++ b/src/classification/speech/mfcc_lstm_classifier.py
@@ -10,6 +10,7 @@ from src.classification.speech.speech_emotion_classifier import (
     SpeechEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class MFCCLSTMClassifier(SpeechEmotionClassifier):
@@ -141,4 +142,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/speech/svm_classifier.py
+++ b/src/classification/speech/svm_classifier.py
@@ -13,6 +13,7 @@ from src.classification.speech.speech_emotion_classifier import (
     SpeechEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy, per_class_accuracy, precision, recall
 
 CLASS_NAMES = [
     "angry",
@@ -190,4 +191,7 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")
+    print(f"Per Class Accuracy: {per_class_accuracy(labels, emotions)}")
+    print(f"Precision: {precision(labels, emotions)}")
+    print(f"Recall: {recall(labels, emotions)}")

--- a/src/classification/speech/wav2vec2_classifier.py
+++ b/src/classification/speech/wav2vec2_classifier.py
@@ -14,6 +14,7 @@ from src.classification.speech.speech_emotion_classifier import (
     SpeechEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class FinetuningWav2Vec2Model(nn.Module):
@@ -300,4 +301,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/text/bert_classifier.py
+++ b/src/classification/text/bert_classifier.py
@@ -13,6 +13,7 @@ from src.classification.text.text_emotion_classifier import (
     TextEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class BertClassifier(TextEmotionClassifier):
@@ -192,4 +193,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/text/distilbert_classifier.py
+++ b/src/classification/text/distilbert_classifier.py
@@ -3,11 +3,11 @@ import os
 import sys
 from typing import Dict
 
-import numpy as np
 import tensorflow as tf
 
 from src.classification.text.bert_classifier import BertClassifier
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class DistilBertClassifier(BertClassifier):
@@ -76,4 +76,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/classification/text/nrclex_classifier.py
+++ b/src/classification/text/nrclex_classifier.py
@@ -8,6 +8,7 @@ from src.classification.text.text_emotion_classifier import (
     TextEmotionClassifier,
 )
 from src.data.data_reader import Set
+from src.utils.metrics import accuracy
 
 
 class NRCLexTextClassifier(TextEmotionClassifier):
@@ -128,4 +129,4 @@ if __name__ == "__main__":  # pragma: no cover
     labels = classifier.data_reader.get_labels(Set.TEST)
     print(f"Labels Shape: {labels.shape}")
     print(f"Emotions Shape: {emotions.shape}")
-    print(f"Accuracy: {np.sum(emotions == labels) / labels.shape[0]}")
+    print(f"Accuracy: {accuracy(labels, emotions)}")

--- a/src/data/data_factory.py
+++ b/src/data/data_factory.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 from src.data.balanced_image_data_reader import BalancedImageDataReader
 from src.data.data_reader import DataReader, Set
 from src.data.image_data_reader import ImageDataReader
+from src.data.plant_exp_reader import PlantExperimentDataReader
 from src.data.speech_data_reader import SpeechDataReader
 from src.data.text_data_reader import TextDataReader
 
@@ -34,6 +35,8 @@ class DataFactory:
             return BalancedImageDataReader(folder=data_folder)
         elif data_type == "speech":
             return SpeechDataReader(folder=data_folder)
+        elif data_type == "plant":
+            return PlantExperimentDataReader(folder=data_folder)
         else:
             raise ValueError(
                 f'The Data Reader for type "{data_type}" ' f"does not exist!"

--- a/src/data/data_reader.py
+++ b/src/data/data_reader.py
@@ -16,6 +16,7 @@ class Set(Enum):
     TRAIN = 0
     VAL = 1
     TEST = 2
+    ALL = 3
 
 
 class DataReader(ABC):

--- a/src/data/data_reader.py
+++ b/src/data/data_reader.py
@@ -156,3 +156,14 @@ class DataReader(ABC):
         return np.concatenate(np_data, axis=0), np.concatenate(
             np_labels, axis=0
         )
+
+    @staticmethod
+    def map_emotions(data, labels):
+        """
+        Conversion function that is applied when three emotion labels are
+        required.
+        """
+        new_labels = DataReader.convert_to_three_emotions_onehot(
+            labels
+        ).astype(np.float32)
+        return data, new_labels

--- a/src/data/experiment_data_reader.py
+++ b/src/data/experiment_data_reader.py
@@ -1,0 +1,93 @@
+""" This file contains a base class for data readers that read experiment
+related data and implements common functionality. """
+
+from typing import Dict
+from abc import abstractmethod
+
+import numpy as np
+import tensorflow as tf
+
+from src.data.data_reader import DataReader, Set
+
+
+class ExperimentDataReader(DataReader):
+    """
+    This is the base class for all experiment related data readers.
+    """
+
+    def __init__(self, name: str, folder: str) -> None:
+        """
+        This function initializes the abstract data reader for experiment data.
+
+        :param name: The name of the data reader to create.
+        :param folder: The folder where the data is located.
+        """
+        super().__init__(name, folder)
+        self.emotions = [
+            "neutral",
+            "joy",
+            "disgust",
+            "anger",
+            "surprise",
+            "sadness",
+            "fear",
+        ]
+        self.emotion_times = self.get_emotion_times()
+
+    def get_emotion_times(self) -> Dict[str, Dict[str, float]]:
+        """
+        This function returns start and end times for every emotion in the
+        experiments.
+
+        :return: The start and end time for every emotion.
+        """
+        starts = [0]
+        ends = []
+        sent_times = [41.03, 98.23, 147.70, 228.16, 287.30, 406.20, 601.80]
+        for i in range(6):
+            starts.append(sent_times[i] + 12)
+            ends.append(sent_times[i] + 12)
+        ends.append(sent_times[6] + 12)
+        emotion_times = {}
+        for emotion, start, end in zip(self.emotions, starts, ends):
+            emotion_times[emotion] = {"start": start, "end": end}
+        return emotion_times
+
+    @abstractmethod
+    def get_seven_emotion_data(self, which_set: Set, batch_size: int = 64,
+                               parameters: Dict = None) -> tf.data.Dataset:
+        """
+        The abstract method for getting the dataset to train on.
+
+        :param which_set: Training, Validation or Test Set
+        :param batch_size: Batch Size for the dataset
+        :param parameters: Additional parameters.
+        :return: A tensorflow Dataset instance.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    @abstractmethod
+    def get_three_emotion_data(self, which_set: Set, batch_size: int = 64,
+                               parameters: Dict = None) -> tf.data.Dataset:
+        """
+        The abstract method for getting the dataset to train on.
+        This method should return only three emotions.
+
+        :param which_set: Training, Validation or Test Set
+        :param batch_size: Batch Size for the dataset
+        :param parameters: Additional parameters.
+        :return: A tensorflow Dataset instance.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    @abstractmethod
+    def get_labels(self, which_set: Set = Set.TRAIN,
+                   parameters: Dict = None) -> np.ndarray:
+        """
+        Return the labels for the unsorted data in the dataset.
+
+        :param which_set: Which set to get labels for
+        :param parameters: Additional parameters
+        :return: Numpy array of labels.
+        """
+        raise NotImplementedError()  # pragma: no cover

--- a/src/data/experiment_data_reader.py
+++ b/src/data/experiment_data_reader.py
@@ -1,8 +1,8 @@
 """ This file contains a base class for data readers that read experiment
 related data and implements common functionality. """
 
-from typing import Dict
 from abc import abstractmethod
+from typing import Dict
 
 import numpy as np
 import tensorflow as tf
@@ -54,8 +54,9 @@ class ExperimentDataReader(DataReader):
         return emotion_times
 
     @abstractmethod
-    def get_seven_emotion_data(self, which_set: Set, batch_size: int = 64,
-                               parameters: Dict = None) -> tf.data.Dataset:
+    def get_seven_emotion_data(
+        self, which_set: Set, batch_size: int = 64, parameters: Dict = None
+    ) -> tf.data.Dataset:
         """
         The abstract method for getting the dataset to train on.
 
@@ -67,8 +68,9 @@ class ExperimentDataReader(DataReader):
         raise NotImplementedError()  # pragma: no cover
 
     @abstractmethod
-    def get_three_emotion_data(self, which_set: Set, batch_size: int = 64,
-                               parameters: Dict = None) -> tf.data.Dataset:
+    def get_three_emotion_data(
+        self, which_set: Set, batch_size: int = 64, parameters: Dict = None
+    ) -> tf.data.Dataset:
         """
         The abstract method for getting the dataset to train on.
         This method should return only three emotions.
@@ -81,8 +83,9 @@ class ExperimentDataReader(DataReader):
         raise NotImplementedError()  # pragma: no cover
 
     @abstractmethod
-    def get_labels(self, which_set: Set = Set.TRAIN,
-                   parameters: Dict = None) -> np.ndarray:
+    def get_labels(
+        self, which_set: Set = Set.TRAIN, parameters: Dict = None
+    ) -> np.ndarray:
         """
         Return the labels for the unsorted data in the dataset.
 

--- a/src/data/experiment_data_reader.py
+++ b/src/data/experiment_data_reader.py
@@ -32,6 +32,15 @@ class ExperimentDataReader(DataReader):
             "sadness",
             "fear",
         ]
+        self.emotion_labels = {
+            "anger": 0,
+            "surprise": 1,
+            "disgust": 2,
+            "joy": 3,
+            "fear": 4,
+            "sadness": 5,
+            "neutral": 6,
+        }
         self.emotion_times = self.get_emotion_times()
 
     def get_emotion_times(self) -> Dict[str, Dict[str, float]]:

--- a/src/data/image_data_reader.py
+++ b/src/data/image_data_reader.py
@@ -111,17 +111,6 @@ class ImageDataReader(DataReader):
         dataset = self.add_augmentations(dataset, augment)
         return dataset
 
-    @staticmethod
-    def map_emotions(data, labels):
-        """
-        Conversion function that is applied when three emotion labels are
-        required.
-        """
-        new_labels = DataReader.convert_to_three_emotions_onehot(
-            labels
-        ).astype(np.float32)
-        return data, new_labels
-
     def get_labels(
         self, which_set: Set = Set.TRAIN, parameters: Dict = None
     ) -> np.ndarray:

--- a/src/data/plant_exp_reader.py
+++ b/src/data/plant_exp_reader.py
@@ -28,17 +28,20 @@ class PlantExperimentDataReader(ExperimentDataReader):
         self.default_label_mode = default_label_mode
         assert default_label_mode in ["expected", "faceapi"]
         self.files = glob.glob(os.path.join(self.folder, "*.wav"))
-        if default_label_mode == "faceapi" and \
-                len(glob.glob("data/ground_truth/*.json")) != len(self.files):
+        if default_label_mode == "faceapi" and len(
+            glob.glob("data/ground_truth/*.json")
+        ) != len(self.files):
             self.prepare_faceapi_labels()
 
-    def get_seven_emotion_data(self, which_set: Set, batch_size: int = 64,
-                               parameters: Dict = None) -> tf.data.Dataset:
+    def get_seven_emotion_data(
+        self, which_set: Set, batch_size: int = 64, parameters: Dict = None
+    ) -> tf.data.Dataset:
         parameters = parameters or {}
-        label_mode = parameters.get("label_mode", self.default_label_mode)
+        _ = parameters.get("label_mode", self.default_label_mode)
 
-    def get_three_emotion_data(self, which_set: Set, batch_size: int = 64,
-                               parameters: Dict = None) -> tf.data.Dataset:
+    def get_three_emotion_data(
+        self, which_set: Set, batch_size: int = 64, parameters: Dict = None
+    ) -> tf.data.Dataset:
         """
         Create a dataset that uses only three emotions.
 
@@ -47,7 +50,9 @@ class PlantExperimentDataReader(ExperimentDataReader):
         :param parameters: Additional parameters
         :return: Dataset with three emotion labels.
         """
-        dataset = self.get_seven_emotion_data(which_set, batch_size, parameters)
+        dataset = self.get_seven_emotion_data(
+            which_set, batch_size, parameters
+        )
         dataset = dataset.map(
             lambda x, y: tf.numpy_function(
                 func=self.map_emotions,
@@ -57,8 +62,9 @@ class PlantExperimentDataReader(ExperimentDataReader):
         )
         return dataset
 
-    def get_labels(self, which_set: Set = Set.TRAIN,
-                   parameters: Dict = None) -> np.ndarray:
+    def get_labels(
+        self, which_set: Set = Set.TRAIN, parameters: Dict = None
+    ) -> np.ndarray:
         """
         This function returns labels for the dataset
 
@@ -73,8 +79,10 @@ class PlantExperimentDataReader(ExperimentDataReader):
         elif label_mode == "faceapi":
             return self.get_faceapi_labels()
         else:
-            raise ValueError(f"Invalid label mode {label_mode}, "
-                             f"please use one of: 'expected', 'faceapi'")
+            raise ValueError(
+                f"Invalid label mode {label_mode}, "
+                f"please use one of: 'expected', 'faceapi'"
+            )
 
     def get_expected_labels(self) -> np.ndarray:
         pass
@@ -89,8 +97,10 @@ class PlantExperimentDataReader(ExperimentDataReader):
         """
         for file in glob.glob("data/video/*.mp4"):
             emotions_file = os.path.join(
-                "data", "ground_truth",
-                f"{os.path.basename(file).split('.')[0]}_emotions.json")
+                "data",
+                "ground_truth",
+                f"{os.path.basename(file).split('.')[0]}_emotions.json",
+            )
             if not os.path.exists(emotions_file):
                 experiment_ground_truth(file)
 

--- a/src/data/plant_exp_reader.py
+++ b/src/data/plant_exp_reader.py
@@ -114,7 +114,7 @@ class PlantExperimentDataReader(ExperimentDataReader):
         """
         if which_set == Set.ALL:
             return list(range(len(self.files)))
-        cv_portions = parameters.get("cv_portions", 8)
+        cv_portions = parameters.get("cv_portions", 5)
         cv_index = parameters.get("cv_index", 0)
         assert cv_portions - 1 >= cv_index >= 0
         borders = np.linspace(0, len(self.files), cv_portions + 1).astype(int)
@@ -310,6 +310,7 @@ if __name__ == "__main__":
     for batch, labels in data:
         print(batch.shape)
         print(labels.shape)
-    all_labels = reader.get_labels(Set.TRAIN, {"label_mode": "faceapi"})
-    print(all_labels.shape)
-    print(np.unique(all_labels, return_counts=True))
+    print(f"Train size: {reader.get_labels(Set.TRAIN).shape[0]}")
+    print(f"Val size: {reader.get_labels(Set.VAL).shape[0]}")
+    print(f"Test size: {reader.get_labels(Set.TEST).shape[0]}")
+    print(f"All size: {reader.get_labels(Set.ALL).shape[0]}")

--- a/src/data/plant_exp_reader.py
+++ b/src/data/plant_exp_reader.py
@@ -1,11 +1,13 @@
 """ This data reader reads the PlantSpikerBox data from the experiments. """
 
 import glob
+import json
 import os
-from typing import Dict
+from typing import Dict, Generator, List, Tuple
 
 import numpy as np
 import tensorflow as tf
+from scipy.io import wavfile
 
 from src.data.data_reader import Set
 from src.data.experiment_data_reader import ExperimentDataReader
@@ -28,16 +30,100 @@ class PlantExperimentDataReader(ExperimentDataReader):
         self.default_label_mode = default_label_mode
         assert default_label_mode in ["expected", "faceapi"]
         self.files = glob.glob(os.path.join(self.folder, "*.wav"))
+        self.files.sort()
         if default_label_mode == "faceapi" and len(
             glob.glob("data/ground_truth/*.json")
         ) != len(self.files):
             self.prepare_faceapi_labels()
+        self.raw_data = None
+        self.raw_labels = None
+        self.sample_rate = 10_000
 
     def get_seven_emotion_data(
         self, which_set: Set, batch_size: int = 64, parameters: Dict = None
     ) -> tf.data.Dataset:
         parameters = parameters or {}
-        _ = parameters.get("label_mode", self.default_label_mode)
+        label_mode = parameters.get("label_mode", self.default_label_mode)
+        window = parameters.get("window", 10)
+        self.get_raw_data()
+        self.get_raw_labels(label_mode)
+        dataset = tf.data.Dataset.from_generator(
+            self.get_data_generator(which_set, parameters),
+            output_types=(tf.float32, tf.float32),
+            output_shapes=(
+                tf.TensorShape([window * self.sample_rate]),
+                tf.TensorShape([]),
+            ),
+        )
+        dataset = dataset.batch(batch_size)
+        return dataset
+
+    def get_data_generator(
+        self, which_set: Set, parameters: Dict
+    ) -> Generator[Tuple[np.ndarray, np.ndarray], None, None]:
+        """
+        Generator that generates the data
+
+        :param which_set: Train, val or test set
+        :param parameters: Additional parameters including:
+            - window: The length of the window to use in seconds
+        :return:
+        """
+
+        def generator():
+            window = parameters.get("window", 10)
+            hop = parameters.get("hop", 5)
+            indices = self.get_cross_validation_indices(which_set, parameters)
+            for data_index in indices:
+                data = self.raw_data[data_index, :]
+                labels = self.raw_labels[data_index, :]
+                for second in range(window, self.raw_labels.shape[1], hop):
+                    yield (
+                        data[
+                            (second - window)
+                            * self.sample_rate : second
+                            * self.sample_rate
+                        ],
+                        np.array(
+                            labels[second]
+                        ),  # TODO: Do I want emotion at the end?
+                    )
+
+        return generator
+
+    def get_cross_validation_indices(
+        self, which_set: Set, parameters: Dict
+    ) -> List[int]:
+        """
+        Generate a list of indices according to CrossValidation.
+
+        :param which_set: Which set to use.
+        :param parameters: Additional parameters including:
+            - cv_portions: Number of cv splits to do.
+            - cv_index: Which split to use.
+        :return: List of indexes in a cv form.
+        """
+        cv_portions = parameters.get("cv_portions", 8)
+        cv_index = parameters.get("cv_index", 0)
+        assert cv_portions - 2 >= cv_index >= 0
+        borders = np.linspace(0, len(self.files), cv_portions + 1).astype(int)
+        if which_set == Set.TEST:
+            test_split = 8 - cv_index
+            return list(range(borders[test_split - 1], borders[test_split]))
+        elif which_set == Set.VAL:
+            val_split = (7 - cv_index) % 8
+            return list(range(borders[val_split - 1], borders[val_split]))
+        elif which_set == Set.TRAIN:
+            indices = []
+            for i in range(1, cv_portions - 1):
+                train_split = (i - cv_index) % 8
+                train_split = (
+                    train_split - 1 if train_split == 0 else train_split
+                )
+                indices.extend(
+                    list(range(borders[train_split - 1], borders[train_split]))
+                )
+            return indices
 
     def get_three_emotion_data(
         self, which_set: Set, batch_size: int = 64, parameters: Dict = None
@@ -90,12 +176,72 @@ class PlantExperimentDataReader(ExperimentDataReader):
     def get_faceapi_labels(self) -> np.ndarray:
         pass
 
+    def get_raw_labels(self, label_mode: str) -> None:
+        """
+        Get the raw labels per experiment and time.
+        Populates the raw_labels member of this class.
+        The two axis are [experiment_index, time_in_seconds]
+
+        :param label_mode: Whether to use expected or faceapi labels
+        """
+        self.raw_labels = np.zeros((len(self.files), 690))
+        if label_mode == "expected":
+            self.get_raw_expected_labels()
+        elif label_mode == "faceapi":
+            self.get_raw_faceapi_labels()
+        self.raw_labels = self.raw_labels[:, :613]
+
+    def get_raw_expected_labels(self):
+        """
+        Load the raw emotions from the expected emotions during the video.
+        """
+        for emotion, times in self.emotion_times.items():
+            self.raw_labels[
+                :, int(times["start"]) : int(times["end"])
+            ] = self.emotion_labels[emotion]
+
+    def get_raw_faceapi_labels(self):
+        """
+        Load the raw labels from the faceapi output files.
+        """
+        emotions_sorted = [
+            "angry",
+            "surprised",
+            "disgusted",
+            "happy",
+            "fearful",
+            "sad",
+            "neutral",
+        ]
+        for file_index, file in enumerate(self.files):
+            experiment_index = os.path.basename(file)[:3]
+            ground_truth_file = glob.glob(
+                f"data/ground_truth/{experiment_index}*.json"
+            )[0]
+            with open(ground_truth_file, "r") as emotions_file:
+                raw_emotions = json.load(emotions_file)
+            previous = None
+            for time, emotion_probs in raw_emotions:
+                time_index = int(float(time)) - 1
+                if emotion_probs != ["undefined"]:
+                    emotion_probs_sorted = [
+                        emotion_probs[0][emotion]
+                        for emotion in emotions_sorted
+                    ]
+                    label = np.argmax(emotion_probs_sorted)
+                    previous = label
+                else:
+                    label = previous
+                self.raw_labels[file_index, time_index] = label
+
     @staticmethod
     def prepare_faceapi_labels() -> None:
         """
         This function prepares the faceapi labels if they are not computed yet.
         """
-        for file in glob.glob("data/video/*.mp4"):
+        video_files = glob.glob("data/video/*.mp4")
+        video_files.sort()
+        for file in video_files:
             emotions_file = os.path.join(
                 "data",
                 "ground_truth",
@@ -104,6 +250,19 @@ class PlantExperimentDataReader(ExperimentDataReader):
             if not os.path.exists(emotions_file):
                 experiment_ground_truth(file)
 
+    def get_raw_data(self) -> None:
+        """
+        Load the raw plant data from the wave files.
+        """
+        self.raw_data = np.zeros((len(self.files), 10000 * 690))
+        for index, plant_file in enumerate(self.files):
+            sample_rate, data = wavfile.read(plant_file)
+            assert sample_rate == 10000, "WAV file has incorrect sample rate!"
+            self.raw_data[index, :] = data
+
 
 if __name__ == "__main__":
-    reader = PlantExperimentDataReader("faceapi")
+    reader = PlantExperimentDataReader()
+    data = reader.get_seven_emotion_data(
+        Set.TRAIN, 64, {"label_mode": "expected"}
+    )

--- a/src/data/plant_exp_reader.py
+++ b/src/data/plant_exp_reader.py
@@ -1,0 +1,99 @@
+""" This data reader reads the PlantSpikerBox data from the experiments. """
+
+import glob
+import os
+from typing import Dict
+
+import numpy as np
+import tensorflow as tf
+
+from src.data.data_reader import Set
+from src.data.experiment_data_reader import ExperimentDataReader
+from src.utils.ground_truth import experiment_ground_truth
+
+
+class PlantExperimentDataReader(ExperimentDataReader):
+    """
+    This data reader reads the plant spiker box files from the experiments
+    """
+
+    def __init__(self, default_label_mode: str = "expected") -> None:
+        """
+        Initialize the plant data reader for the experiment data.
+
+        :param default_label_mode: Whether to use expected emotion
+            or face as ground truth.
+        """
+        super().__init__("plant_exp", "data/plant")
+        self.default_label_mode = default_label_mode
+        assert default_label_mode in ["expected", "faceapi"]
+        self.files = glob.glob(os.path.join(self.folder, "*.wav"))
+        if default_label_mode == "faceapi" and \
+                len(glob.glob("data/ground_truth/*.json")) != len(self.files):
+            self.prepare_faceapi_labels()
+
+    def get_seven_emotion_data(self, which_set: Set, batch_size: int = 64,
+                               parameters: Dict = None) -> tf.data.Dataset:
+        parameters = parameters or {}
+        label_mode = parameters.get("label_mode", self.default_label_mode)
+
+    def get_three_emotion_data(self, which_set: Set, batch_size: int = 64,
+                               parameters: Dict = None) -> tf.data.Dataset:
+        """
+        Create a dataset that uses only three emotions.
+
+        :param which_set: Which set: Train, val or test
+        :param batch_size: Batch size
+        :param parameters: Additional parameters
+        :return: Dataset with three emotion labels.
+        """
+        dataset = self.get_seven_emotion_data(which_set, batch_size, parameters)
+        dataset = dataset.map(
+            lambda x, y: tf.numpy_function(
+                func=self.map_emotions,
+                inp=[x, y],
+                Tout=(tf.float32, tf.float32),
+            )
+        )
+        return dataset
+
+    def get_labels(self, which_set: Set = Set.TRAIN,
+                   parameters: Dict = None) -> np.ndarray:
+        """
+        This function returns labels for the dataset
+
+        :param which_set: Which set to get the labels for.
+        :param parameters: Additional parameters.
+        :return: Label numpy array
+        """
+        parameters = parameters or {}
+        label_mode = parameters.get("label_mode", self.default_label_mode)
+        if label_mode == "expected":
+            return self.get_expected_labels()
+        elif label_mode == "faceapi":
+            return self.get_faceapi_labels()
+        else:
+            raise ValueError(f"Invalid label mode {label_mode}, "
+                             f"please use one of: 'expected', 'faceapi'")
+
+    def get_expected_labels(self) -> np.ndarray:
+        pass
+
+    def get_faceapi_labels(self) -> np.ndarray:
+        pass
+
+    @staticmethod
+    def prepare_faceapi_labels() -> None:
+        """
+        This function prepares the faceapi labels if they are not computed yet.
+        """
+        for file in glob.glob("data/video/*.mp4"):
+            emotions_file = os.path.join(
+                "data", "ground_truth",
+                f"{os.path.basename(file).split('.')[0]}_emotions.json")
+            if not os.path.exists(emotions_file):
+                experiment_ground_truth(file)
+
+
+if __name__ == "__main__":
+    reader = PlantExperimentDataReader("faceapi")

--- a/src/data/plant_exp_reader.py
+++ b/src/data/plant_exp_reader.py
@@ -38,7 +38,7 @@ class PlantExperimentDataReader(ExperimentDataReader):
             glob.glob("data/ground_truth/*.json")
         ) != len(self.files):
             self.prepare_faceapi_labels()
-        self.raw_data = None
+        self.raw_data = []
         self.raw_labels = None
         self.sample_rate = 10_000
 
@@ -82,7 +82,7 @@ class PlantExperimentDataReader(ExperimentDataReader):
             preprocess = parameters.get("preprocess", True)
             indices = self.get_cross_validation_indices(which_set, parameters)
             for data_index in indices:
-                data = self.raw_data[data_index, :]
+                data = self.raw_data[data_index]
                 labels = self.raw_labels[data_index, :]
                 for second in range(window, self.raw_labels.shape[1], hop):
                     sample = data[
@@ -258,14 +258,14 @@ class PlantExperimentDataReader(ExperimentDataReader):
         """
         Load the raw plant data from the wave files.
         """
-        self.raw_data = np.zeros((len(self.files), 10000 * 690))
+        self.raw_data = []
         for index, plant_file in enumerate(self.files):
             sample_rate, data = wavfile.read(plant_file)
             assert sample_rate == 10000, "WAV file has incorrect sample rate!"
             mean = np.mean(data)
             var = np.var(data)
             data = (data - mean) / var
-            self.raw_data[index, :] = data
+            self.raw_data.append(data)
 
     @staticmethod
     def preprocess_sample(

--- a/src/data/plant_exp_reader.py
+++ b/src/data/plant_exp_reader.py
@@ -262,9 +262,13 @@ class PlantExperimentDataReader(ExperimentDataReader):
 
 if __name__ == "__main__":
     reader = PlantExperimentDataReader()
+    reader.prepare_faceapi_labels()
     data = reader.get_seven_emotion_data(
         Set.TRAIN, 64, {"label_mode": "expected"}
     ).take(1)
     for batch, labels in data:
         print(batch.shape)
         print(labels.shape)
+    all_labels = reader.get_labels(Set.TRAIN)
+    print(all_labels.shape)
+    print(np.unique(all_labels, return_counts=True))

--- a/src/experiment/cv_experiment.py
+++ b/src/experiment/cv_experiment.py
@@ -43,8 +43,8 @@ class CrossValidationExperimentRunner(ExperimentRunner):
         print(experiment.get_parameter_dict())
 
         labels = ClassifierFactory.get(
-            experiment.modality, experiment.model, experiment.train_parameters
-        ).data_reader.get_labels(Set.ALL)
+            experiment.modality, experiment.model, experiment.init_parameters
+        ).data_reader.get_labels(Set.ALL, experiment.train_parameters)
 
         # If already exists
         file_path = f"{index:03d}_results.json"

--- a/src/experiment/cv_experiment.py
+++ b/src/experiment/cv_experiment.py
@@ -1,0 +1,89 @@
+"""Experiment running functionality for grid searching parameters
+with cross validation ."""
+
+import json
+import os
+
+import numpy as np
+
+from src.classification.classifier_factory import ClassifierFactory
+from src.data.data_reader import Set
+from src.experiment.experiment import Experiment, ExperimentRunner
+
+
+class CrossValidationExperimentRunner(ExperimentRunner):
+    """
+    Experiment runner class to run multiple experiments easily
+    while also using cross validation
+    """
+
+    def __init__(self, experiment_name: str, cv_splits: int = 5, **kwargs):
+        """
+        Constructor for the ExperimentRunner class
+        :param experiment_name: Name of the experiment for log files and result
+        :param cv_splits: How many splits to do in cross validation
+        :param kwargs: Additional keyword arguments
+            Not currently used
+        """
+        super().__init__(experiment_name, **kwargs)
+        self.cv_splits = cv_splits
+
+    def run_experiment(
+        self, experiment: Experiment, index: int, **kwargs
+    ) -> float:
+        """
+        Run an experiment and save the results in a json file
+
+        :param experiment: The experiment configuration to use
+        :param index: The index of the experiment for saving the results
+        :param kwargs: Additional kwargs
+            data_reader: Overwrite data reader for testing purposes
+        """
+        print(f"Running experiment {index}")
+        print(experiment.get_parameter_dict())
+
+        labels = ClassifierFactory.get(
+            experiment.modality, experiment.model, experiment.init_parameters
+        ).data_reader.get_labels(Set.ALL)
+
+        # If already exists
+        file_path = f"{index:03d}_results.json"
+        if os.path.exists(os.path.join(self.folder, file_path)):
+            print("Skipping experiment as results already exist!")
+            with open(os.path.join(self.folder, file_path), "r") as json_file:
+                data = json.load(json_file)
+                return np.sum(data["predictions"] == labels) / labels.shape[0]
+
+        predictions = np.empty(
+            [
+                0,
+            ]
+        )
+
+        for cv_split in range(self.cv_splits):
+            classifier = ClassifierFactory.get(
+                experiment.modality,
+                experiment.model,
+                experiment.init_parameters,
+            )
+            classifier.data_reader = kwargs.get(
+                "data_reader", classifier.data_reader
+            )
+            labels = classifier.data_reader.get_labels(
+                Set.TEST, experiment.train_parameters
+            )
+            train_parameters = experiment.train_parameters.copy()
+            train_parameters["cv_portions"] = self.cv_splits
+            train_parameters["cv_index"] = cv_split
+            classifier.train(train_parameters)
+            eval_parameters = train_parameters.copy()
+            eval_parameters["which_set"] = Set.TEST
+            test_predictions = classifier.classify(eval_parameters)
+            predictions = np.concatenate(
+                [test_predictions, predictions], axis=0
+            )
+        parameters = experiment.get_parameter_dict()
+        parameters["predictions"] = predictions.tolist()
+        with open(os.path.join(self.folder, file_path), "w") as json_file:
+            json.dump(parameters, json_file)
+        return np.sum(parameters["predictions"] == labels) / labels.shape[0]

--- a/src/experiment/cv_experiment.py
+++ b/src/experiment/cv_experiment.py
@@ -43,7 +43,7 @@ class CrossValidationExperimentRunner(ExperimentRunner):
         print(experiment.get_parameter_dict())
 
         labels = ClassifierFactory.get(
-            experiment.modality, experiment.model, experiment.init_parameters
+            experiment.modality, experiment.model, experiment.train_parameters
         ).data_reader.get_labels(Set.ALL)
 
         # If already exists

--- a/src/experiment/cv_experiment.py
+++ b/src/experiment/cv_experiment.py
@@ -72,6 +72,8 @@ class CrossValidationExperimentRunner(ExperimentRunner):
             predictions = np.concatenate(
                 [test_predictions, predictions], axis=0
             )
+            del classifier.data_reader.raw_data
+            del classifier.data_reader.raw_labels
         parameters = experiment.get_parameter_dict()
         parameters["predictions"] = predictions.tolist()
         with open(os.path.join(self.folder, file_path), "w") as json_file:

--- a/src/experiment/cv_experiment.py
+++ b/src/experiment/cv_experiment.py
@@ -76,4 +76,4 @@ class CrossValidationExperimentRunner(ExperimentRunner):
         parameters["predictions"] = predictions.tolist()
         with open(os.path.join(self.folder, file_path), "w") as json_file:
             json.dump(parameters, json_file)
-        return np.sum(parameters["predictions"] == labels) / labels.shape[0]
+        return np.sum(predictions == labels) / labels.shape[0]

--- a/src/experiment/cv_experiment.py
+++ b/src/experiment/cv_experiment.py
@@ -54,23 +54,13 @@ class CrossValidationExperimentRunner(ExperimentRunner):
                 data = json.load(json_file)
                 return np.sum(data["predictions"] == labels) / labels.shape[0]
 
-        predictions = np.empty(
-            [
-                0,
-            ]
-        )
+        predictions = np.empty((0,))
 
         for cv_split in range(self.cv_splits):
             classifier = ClassifierFactory.get(
                 experiment.modality,
                 experiment.model,
                 experiment.init_parameters,
-            )
-            classifier.data_reader = kwargs.get(
-                "data_reader", classifier.data_reader
-            )
-            labels = classifier.data_reader.get_labels(
-                Set.TEST, experiment.train_parameters
             )
             train_parameters = experiment.train_parameters.copy()
             train_parameters["cv_portions"] = self.cv_splits

--- a/src/experiment/experiment.py
+++ b/src/experiment/experiment.py
@@ -69,7 +69,7 @@ class Experiment:
         This function either throws an Assertion Error or Value Error in case
         of wrong parameters.
         """
-        assert self.modality in ["text", "image", "speech"]
+        assert self.modality in ["text", "image", "speech", "plant"]
         _ = ClassifierFactory.get(self.modality, self.model, {})
         assert (
             isinstance(self.train_parameters, dict)

--- a/src/utils/faceapi/commons/env.ts
+++ b/src/utils/faceapi/commons/env.ts
@@ -1,0 +1,15 @@
+// import nodejs bindings to native tensorflow,
+// not required, but will speed up things drastically (python required)
+import '@tensorflow/tfjs-node';
+
+import * as faceapi from 'face-api.js';
+
+// implements nodejs wrappers for HTMLCanvasElement, HTMLImageElement, ImageData
+const canvas = require('canvas')
+
+// patch nodejs environment, we need to provide an implementation of
+// HTMLCanvasElement and HTMLImageElement
+const { Canvas, Image, ImageData } = canvas
+faceapi.env.monkeyPatch({ Canvas, Image, ImageData })
+
+export { canvas }

--- a/src/utils/faceapi/commons/index.ts
+++ b/src/utils/faceapi/commons/index.ts
@@ -1,0 +1,1 @@
+export { canvas } from './env';

--- a/src/utils/faceapi/deploy.prototxt
+++ b/src/utils/faceapi/deploy.prototxt
@@ -1,0 +1,1789 @@
+input: "data"
+input_shape {
+  dim: 1
+  dim: 3
+  dim: 300
+  dim: 300
+}
+
+layer {
+  name: "data_bn"
+  type: "BatchNorm"
+  bottom: "data"
+  top: "data_bn"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "data_scale"
+  type: "Scale"
+  bottom: "data_bn"
+  top: "data_bn"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "conv1_h"
+  type: "Convolution"
+  bottom: "data_bn"
+  top: "conv1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 32
+    pad: 3
+    kernel_size: 7
+    stride: 2
+    weight_filler {
+      type: "msra"
+      variance_norm: FAN_OUT
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "conv1_bn_h"
+  type: "BatchNorm"
+  bottom: "conv1_h"
+  top: "conv1_h"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "conv1_scale_h"
+  type: "Scale"
+  bottom: "conv1_h"
+  top: "conv1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "conv1_relu"
+  type: "ReLU"
+  bottom: "conv1_h"
+  top: "conv1_h"
+}
+layer {
+  name: "conv1_pool"
+  type: "Pooling"
+  bottom: "conv1_h"
+  top: "conv1_pool"
+  pooling_param {
+    kernel_size: 3
+    stride: 2
+  }
+}
+layer {
+  name: "layer_64_1_conv1_h"
+  type: "Convolution"
+  bottom: "conv1_pool"
+  top: "layer_64_1_conv1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 32
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_64_1_bn2_h"
+  type: "BatchNorm"
+  bottom: "layer_64_1_conv1_h"
+  top: "layer_64_1_conv1_h"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "layer_64_1_scale2_h"
+  type: "Scale"
+  bottom: "layer_64_1_conv1_h"
+  top: "layer_64_1_conv1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "layer_64_1_relu2"
+  type: "ReLU"
+  bottom: "layer_64_1_conv1_h"
+  top: "layer_64_1_conv1_h"
+}
+layer {
+  name: "layer_64_1_conv2_h"
+  type: "Convolution"
+  bottom: "layer_64_1_conv1_h"
+  top: "layer_64_1_conv2_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 32
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_64_1_sum"
+  type: "Eltwise"
+  bottom: "layer_64_1_conv2_h"
+  bottom: "conv1_pool"
+  top: "layer_64_1_sum"
+}
+layer {
+  name: "layer_128_1_bn1_h"
+  type: "BatchNorm"
+  bottom: "layer_64_1_sum"
+  top: "layer_128_1_bn1_h"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "layer_128_1_scale1_h"
+  type: "Scale"
+  bottom: "layer_128_1_bn1_h"
+  top: "layer_128_1_bn1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "layer_128_1_relu1"
+  type: "ReLU"
+  bottom: "layer_128_1_bn1_h"
+  top: "layer_128_1_bn1_h"
+}
+layer {
+  name: "layer_128_1_conv1_h"
+  type: "Convolution"
+  bottom: "layer_128_1_bn1_h"
+  top: "layer_128_1_conv1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_128_1_bn2"
+  type: "BatchNorm"
+  bottom: "layer_128_1_conv1_h"
+  top: "layer_128_1_conv1_h"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "layer_128_1_scale2"
+  type: "Scale"
+  bottom: "layer_128_1_conv1_h"
+  top: "layer_128_1_conv1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "layer_128_1_relu2"
+  type: "ReLU"
+  bottom: "layer_128_1_conv1_h"
+  top: "layer_128_1_conv1_h"
+}
+layer {
+  name: "layer_128_1_conv2"
+  type: "Convolution"
+  bottom: "layer_128_1_conv1_h"
+  top: "layer_128_1_conv2"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_128_1_conv_expand_h"
+  type: "Convolution"
+  bottom: "layer_128_1_bn1_h"
+  top: "layer_128_1_conv_expand_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_128_1_sum"
+  type: "Eltwise"
+  bottom: "layer_128_1_conv2"
+  bottom: "layer_128_1_conv_expand_h"
+  top: "layer_128_1_sum"
+}
+layer {
+  name: "layer_256_1_bn1"
+  type: "BatchNorm"
+  bottom: "layer_128_1_sum"
+  top: "layer_256_1_bn1"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "layer_256_1_scale1"
+  type: "Scale"
+  bottom: "layer_256_1_bn1"
+  top: "layer_256_1_bn1"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "layer_256_1_relu1"
+  type: "ReLU"
+  bottom: "layer_256_1_bn1"
+  top: "layer_256_1_bn1"
+}
+layer {
+  name: "layer_256_1_conv1"
+  type: "Convolution"
+  bottom: "layer_256_1_bn1"
+  top: "layer_256_1_conv1"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_256_1_bn2"
+  type: "BatchNorm"
+  bottom: "layer_256_1_conv1"
+  top: "layer_256_1_conv1"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "layer_256_1_scale2"
+  type: "Scale"
+  bottom: "layer_256_1_conv1"
+  top: "layer_256_1_conv1"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "layer_256_1_relu2"
+  type: "ReLU"
+  bottom: "layer_256_1_conv1"
+  top: "layer_256_1_conv1"
+}
+layer {
+  name: "layer_256_1_conv2"
+  type: "Convolution"
+  bottom: "layer_256_1_conv1"
+  top: "layer_256_1_conv2"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_256_1_conv_expand"
+  type: "Convolution"
+  bottom: "layer_256_1_bn1"
+  top: "layer_256_1_conv_expand"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_256_1_sum"
+  type: "Eltwise"
+  bottom: "layer_256_1_conv2"
+  bottom: "layer_256_1_conv_expand"
+  top: "layer_256_1_sum"
+}
+layer {
+  name: "layer_512_1_bn1"
+  type: "BatchNorm"
+  bottom: "layer_256_1_sum"
+  top: "layer_512_1_bn1"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "layer_512_1_scale1"
+  type: "Scale"
+  bottom: "layer_512_1_bn1"
+  top: "layer_512_1_bn1"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "layer_512_1_relu1"
+  type: "ReLU"
+  bottom: "layer_512_1_bn1"
+  top: "layer_512_1_bn1"
+}
+layer {
+  name: "layer_512_1_conv1_h"
+  type: "Convolution"
+  bottom: "layer_512_1_bn1"
+  top: "layer_512_1_conv1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 1 # 2
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_512_1_bn2_h"
+  type: "BatchNorm"
+  bottom: "layer_512_1_conv1_h"
+  top: "layer_512_1_conv1_h"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "layer_512_1_scale2_h"
+  type: "Scale"
+  bottom: "layer_512_1_conv1_h"
+  top: "layer_512_1_conv1_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "layer_512_1_relu2"
+  type: "ReLU"
+  bottom: "layer_512_1_conv1_h"
+  top: "layer_512_1_conv1_h"
+}
+layer {
+  name: "layer_512_1_conv2_h"
+  type: "Convolution"
+  bottom: "layer_512_1_conv1_h"
+  top: "layer_512_1_conv2_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 2 # 1
+    kernel_size: 3
+    stride: 1
+    dilation: 2
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_512_1_conv_expand_h"
+  type: "Convolution"
+  bottom: "layer_512_1_bn1"
+  top: "layer_512_1_conv_expand_h"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1 # 2
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+  }
+}
+layer {
+  name: "layer_512_1_sum"
+  type: "Eltwise"
+  bottom: "layer_512_1_conv2_h"
+  bottom: "layer_512_1_conv_expand_h"
+  top: "layer_512_1_sum"
+}
+layer {
+  name: "last_bn_h"
+  type: "BatchNorm"
+  bottom: "layer_512_1_sum"
+  top: "layer_512_1_sum"
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+  param {
+    lr_mult: 0.0
+  }
+}
+layer {
+  name: "last_scale_h"
+  type: "Scale"
+  bottom: "layer_512_1_sum"
+  top: "layer_512_1_sum"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 1.0
+  }
+  scale_param {
+    bias_term: true
+  }
+}
+layer {
+  name: "last_relu"
+  type: "ReLU"
+  bottom: "layer_512_1_sum"
+  top: "fc7"
+}
+
+layer {
+  name: "conv6_1_h"
+  type: "Convolution"
+  bottom: "fc7"
+  top: "conv6_1_h"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv6_1_relu"
+  type: "ReLU"
+  bottom: "conv6_1_h"
+  top: "conv6_1_h"
+}
+layer {
+  name: "conv6_2_h"
+  type: "Convolution"
+  bottom: "conv6_1_h"
+  top: "conv6_2_h"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv6_2_relu"
+  type: "ReLU"
+  bottom: "conv6_2_h"
+  top: "conv6_2_h"
+}
+layer {
+  name: "conv7_1_h"
+  type: "Convolution"
+  bottom: "conv6_2_h"
+  top: "conv7_1_h"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv7_1_relu"
+  type: "ReLU"
+  bottom: "conv7_1_h"
+  top: "conv7_1_h"
+}
+layer {
+  name: "conv7_2_h"
+  type: "Convolution"
+  bottom: "conv7_1_h"
+  top: "conv7_2_h"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv7_2_relu"
+  type: "ReLU"
+  bottom: "conv7_2_h"
+  top: "conv7_2_h"
+}
+layer {
+  name: "conv8_1_h"
+  type: "Convolution"
+  bottom: "conv7_2_h"
+  top: "conv8_1_h"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv8_1_relu"
+  type: "ReLU"
+  bottom: "conv8_1_h"
+  top: "conv8_1_h"
+}
+layer {
+  name: "conv8_2_h"
+  type: "Convolution"
+  bottom: "conv8_1_h"
+  top: "conv8_2_h"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv8_2_relu"
+  type: "ReLU"
+  bottom: "conv8_2_h"
+  top: "conv8_2_h"
+}
+layer {
+  name: "conv9_1_h"
+  type: "Convolution"
+  bottom: "conv8_2_h"
+  top: "conv9_1_h"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv9_1_relu"
+  type: "ReLU"
+  bottom: "conv9_1_h"
+  top: "conv9_1_h"
+}
+layer {
+  name: "conv9_2_h"
+  type: "Convolution"
+  bottom: "conv9_1_h"
+  top: "conv9_2_h"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv9_2_relu"
+  type: "ReLU"
+  bottom: "conv9_2_h"
+  top: "conv9_2_h"
+}
+layer {
+  name: "conv4_3_norm"
+  type: "Normalize"
+  bottom: "layer_256_1_bn1"
+  top: "conv4_3_norm"
+  norm_param {
+    across_spatial: false
+    scale_filler {
+      type: "constant"
+      value: 20
+    }
+    channel_shared: false
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_loc"
+  type: "Convolution"
+  bottom: "conv4_3_norm"
+  top: "conv4_3_norm_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 16
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv4_3_norm_mbox_loc"
+  top: "conv4_3_norm_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv4_3_norm_mbox_loc_perm"
+  top: "conv4_3_norm_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_conf"
+  type: "Convolution"
+  bottom: "conv4_3_norm"
+  top: "conv4_3_norm_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 8 # 84
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv4_3_norm_mbox_conf"
+  top: "conv4_3_norm_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv4_3_norm_mbox_conf_perm"
+  top: "conv4_3_norm_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv4_3_norm"
+  bottom: "data"
+  top: "conv4_3_norm_mbox_priorbox"
+  prior_box_param {
+    min_size: 30.0
+    max_size: 60.0
+    aspect_ratio: 2
+    flip: true
+    clip: false
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+    step: 8
+    offset: 0.5
+  }
+}
+layer {
+  name: "fc7_mbox_loc"
+  type: "Convolution"
+  bottom: "fc7"
+  top: "fc7_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "fc7_mbox_loc_perm"
+  type: "Permute"
+  bottom: "fc7_mbox_loc"
+  top: "fc7_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "fc7_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "fc7_mbox_loc_perm"
+  top: "fc7_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "fc7_mbox_conf"
+  type: "Convolution"
+  bottom: "fc7"
+  top: "fc7_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 12 # 126
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "fc7_mbox_conf_perm"
+  type: "Permute"
+  bottom: "fc7_mbox_conf"
+  top: "fc7_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "fc7_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "fc7_mbox_conf_perm"
+  top: "fc7_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "fc7_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "fc7"
+  bottom: "data"
+  top: "fc7_mbox_priorbox"
+  prior_box_param {
+    min_size: 60.0
+    max_size: 111.0
+    aspect_ratio: 2
+    aspect_ratio: 3
+    flip: true
+    clip: false
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+    step: 16
+    offset: 0.5
+  }
+}
+layer {
+  name: "conv6_2_mbox_loc"
+  type: "Convolution"
+  bottom: "conv6_2_h"
+  top: "conv6_2_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv6_2_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv6_2_mbox_loc"
+  top: "conv6_2_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv6_2_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv6_2_mbox_loc_perm"
+  top: "conv6_2_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv6_2_mbox_conf"
+  type: "Convolution"
+  bottom: "conv6_2_h"
+  top: "conv6_2_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 12 # 126
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv6_2_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv6_2_mbox_conf"
+  top: "conv6_2_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv6_2_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv6_2_mbox_conf_perm"
+  top: "conv6_2_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv6_2_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv6_2_h"
+  bottom: "data"
+  top: "conv6_2_mbox_priorbox"
+  prior_box_param {
+    min_size: 111.0
+    max_size: 162.0
+    aspect_ratio: 2
+    aspect_ratio: 3
+    flip: true
+    clip: false
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+    step: 32
+    offset: 0.5
+  }
+}
+layer {
+  name: "conv7_2_mbox_loc"
+  type: "Convolution"
+  bottom: "conv7_2_h"
+  top: "conv7_2_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv7_2_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv7_2_mbox_loc"
+  top: "conv7_2_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv7_2_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv7_2_mbox_loc_perm"
+  top: "conv7_2_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv7_2_mbox_conf"
+  type: "Convolution"
+  bottom: "conv7_2_h"
+  top: "conv7_2_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 12 # 126
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv7_2_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv7_2_mbox_conf"
+  top: "conv7_2_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv7_2_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv7_2_mbox_conf_perm"
+  top: "conv7_2_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv7_2_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv7_2_h"
+  bottom: "data"
+  top: "conv7_2_mbox_priorbox"
+  prior_box_param {
+    min_size: 162.0
+    max_size: 213.0
+    aspect_ratio: 2
+    aspect_ratio: 3
+    flip: true
+    clip: false
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+    step: 64
+    offset: 0.5
+  }
+}
+layer {
+  name: "conv8_2_mbox_loc"
+  type: "Convolution"
+  bottom: "conv8_2_h"
+  top: "conv8_2_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 16
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv8_2_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv8_2_mbox_loc"
+  top: "conv8_2_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv8_2_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv8_2_mbox_loc_perm"
+  top: "conv8_2_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv8_2_mbox_conf"
+  type: "Convolution"
+  bottom: "conv8_2_h"
+  top: "conv8_2_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 8 # 84
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv8_2_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv8_2_mbox_conf"
+  top: "conv8_2_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv8_2_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv8_2_mbox_conf_perm"
+  top: "conv8_2_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv8_2_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv8_2_h"
+  bottom: "data"
+  top: "conv8_2_mbox_priorbox"
+  prior_box_param {
+    min_size: 213.0
+    max_size: 264.0
+    aspect_ratio: 2
+    flip: true
+    clip: false
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+    step: 100
+    offset: 0.5
+  }
+}
+layer {
+  name: "conv9_2_mbox_loc"
+  type: "Convolution"
+  bottom: "conv9_2_h"
+  top: "conv9_2_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 16
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv9_2_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv9_2_mbox_loc"
+  top: "conv9_2_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv9_2_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv9_2_mbox_loc_perm"
+  top: "conv9_2_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv9_2_mbox_conf"
+  type: "Convolution"
+  bottom: "conv9_2_h"
+  top: "conv9_2_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 8 # 84
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv9_2_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv9_2_mbox_conf"
+  top: "conv9_2_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv9_2_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv9_2_mbox_conf_perm"
+  top: "conv9_2_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv9_2_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv9_2_h"
+  bottom: "data"
+  top: "conv9_2_mbox_priorbox"
+  prior_box_param {
+    min_size: 264.0
+    max_size: 315.0
+    aspect_ratio: 2
+    flip: true
+    clip: false
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+    step: 300
+    offset: 0.5
+  }
+}
+layer {
+  name: "mbox_loc"
+  type: "Concat"
+  bottom: "conv4_3_norm_mbox_loc_flat"
+  bottom: "fc7_mbox_loc_flat"
+  bottom: "conv6_2_mbox_loc_flat"
+  bottom: "conv7_2_mbox_loc_flat"
+  bottom: "conv8_2_mbox_loc_flat"
+  bottom: "conv9_2_mbox_loc_flat"
+  top: "mbox_loc"
+  concat_param {
+    axis: 1
+  }
+}
+layer {
+  name: "mbox_conf"
+  type: "Concat"
+  bottom: "conv4_3_norm_mbox_conf_flat"
+  bottom: "fc7_mbox_conf_flat"
+  bottom: "conv6_2_mbox_conf_flat"
+  bottom: "conv7_2_mbox_conf_flat"
+  bottom: "conv8_2_mbox_conf_flat"
+  bottom: "conv9_2_mbox_conf_flat"
+  top: "mbox_conf"
+  concat_param {
+    axis: 1
+  }
+}
+layer {
+  name: "mbox_priorbox"
+  type: "Concat"
+  bottom: "conv4_3_norm_mbox_priorbox"
+  bottom: "fc7_mbox_priorbox"
+  bottom: "conv6_2_mbox_priorbox"
+  bottom: "conv7_2_mbox_priorbox"
+  bottom: "conv8_2_mbox_priorbox"
+  bottom: "conv9_2_mbox_priorbox"
+  top: "mbox_priorbox"
+  concat_param {
+    axis: 2
+  }
+}
+
+layer {
+  name: "mbox_conf_reshape"
+  type: "Reshape"
+  bottom: "mbox_conf"
+  top: "mbox_conf_reshape"
+  reshape_param {
+    shape {
+      dim: 0
+      dim: -1
+      dim: 2
+    }
+  }
+}
+layer {
+  name: "mbox_conf_softmax"
+  type: "Softmax"
+  bottom: "mbox_conf_reshape"
+  top: "mbox_conf_softmax"
+  softmax_param {
+    axis: 2
+  }
+}
+layer {
+  name: "mbox_conf_flatten"
+  type: "Flatten"
+  bottom: "mbox_conf_softmax"
+  top: "mbox_conf_flatten"
+  flatten_param {
+    axis: 1
+  }
+}
+
+layer {
+  name: "detection_out"
+  type: "DetectionOutput"
+  bottom: "mbox_loc"
+  bottom: "mbox_conf_flatten"
+  bottom: "mbox_priorbox"
+  top: "detection_out"
+  include {
+    phase: TEST
+  }
+  detection_output_param {
+    num_classes: 2
+    share_location: true
+    background_label_id: 0
+    nms_param {
+      nms_threshold: 0.3
+      top_k: 400
+    }
+    code_type: CENTER_SIZE
+    keep_top_k: 200
+    confidence_threshold: 0.01
+  }
+}

--- a/src/utils/faceapi/emotions.ts
+++ b/src/utils/faceapi/emotions.ts
@@ -1,0 +1,40 @@
+// @ts-ignore
+import express, {NextFunction, Request, Response} from 'express';
+import * as faceapi from "face-api.js";
+import {tensor3d} from "@tensorflow/tfjs-core";
+require('@tensorflow/tfjs-node');
+const router = express.Router();
+
+
+// getting the emotions
+const getEmotions = async (req: Request, res: Response, next: NextFunction) => {
+    await faceapi.nets.tinyFaceDetector.loadFromDisk('weights')
+    await faceapi.nets.faceLandmark68Net.loadFromDisk('weights')
+    await faceapi.nets.faceRecognitionNet.loadFromDisk('weights')
+    await faceapi.nets.faceExpressionNet.loadFromDisk('weights')
+
+    let image = req.body.image;
+    let tensor = tensor3d(image, [540, 960, 3])
+
+    const results = await faceapi.detectAllFaces(tensor,
+      new faceapi.TinyFaceDetectorOptions())
+    .withFaceLandmarks()
+    .withFaceExpressions()
+
+    const displaySize = { width: 960, height: 540 }
+    const resizedDetections = faceapi.resizeResults(results, displaySize)
+    if (resizedDetections[0] != undefined) {
+        return res.status(200).json({
+            message: resizedDetections[0]["expressions"]
+        });
+    } else {
+        return res.status(200).json({
+            message: "undefined"
+        });
+    }
+
+};
+
+router.post('/emotions', getEmotions);
+
+export = router;

--- a/src/utils/faceapi/package.json
+++ b/src/utils/faceapi/package.json
@@ -1,0 +1,24 @@
+{
+  "main": "./server.ts",
+  "scripts": {
+    "dev": "nodemon ./server.ts",
+    "build": "rm -rf build/ && prettier --write source/ && tsc"
+  },
+  "dependencies": {
+    "@tensorflow/tfjs-core": "1.7.0",
+    "@tensorflow/tfjs-node": "1.7.0",
+    "@types/axios": "^0.14.0",
+    "@types/express": "^4.17.13",
+    "@types/morgan": "^1.9.3",
+    "@types/node": "^18.0.0",
+    "axios": "^0.27.2",
+    "canvas": "^2.9.3",
+    "express": "^4.18.1",
+    "face-api.js": "^0.22.2",
+    "morgan": "^1.10.0",
+    "nodemon": "^2.0.18",
+    "ts-node": "^10.8.1",
+    "tslib": "^1.11.1",
+    "typescript": "^4.7.4"
+  }
+}

--- a/src/utils/faceapi/server.ts
+++ b/src/utils/faceapi/server.ts
@@ -1,0 +1,45 @@
+// @ts-ignore
+import http from 'http';
+// @ts-ignore
+import express, { Express } from 'express';
+// @ts-ignore
+import morgan from 'morgan';
+// @ts-ignore
+import routes from './emotions';
+
+const router: Express = express();
+
+/** Logging */
+router.use(morgan('dev'));
+/** Parse the request */
+router.use(express.json({limit: '100mb'}));
+router.use(express.urlencoded({limit: '100mb', extended: false}));
+
+/** RULES OF OUR API */
+router.use((req, res, next) => {
+    // set the CORS policy
+    res.header('Access-Control-Allow-Origin', '*');
+    // set the CORS headers
+    res.header('Access-Control-Allow-Headers', 'origin, X-Requested-With,Content-Type,Accept, Authorization');
+    // set the CORS method headers
+    if (req.method === 'OPTIONS') {
+        res.header('Access-Control-Allow-Methods', 'GET PATCH DELETE POST');
+        return res.status(200).json({});
+    }
+    next();
+});
+
+router.use('/', routes);
+
+/** Error handling */
+router.use((req, res, next) => {
+    const error = new Error('not found');
+    return res.status(404).json({
+        message: error.message
+    });
+});
+
+/** Server */
+const httpServer = http.createServer(router);
+const PORT: any = process.env.PORT ?? 6060;
+httpServer.listen(PORT, () => console.log(`The server is running on port ${PORT}`));

--- a/src/utils/faceapi/setup.sh
+++ b/src/utils/faceapi/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd $(dirname "$BASH_SOURCE")
+
+sudo apt update
+sudo apt install nodejs npm
+
+npm i
+
+if [ ! -d "weights" ]; then
+  mkdir weights
+fi
+cd weights
+wget https://raw.githubusercontent.com/justadudewhohacks/face-api.js/master/weights/tiny_face_detector_model-weights_manifest.json
+wget https://github.com/justadudewhohacks/face-api.js/raw/master/weights/tiny_face_detector_model-shard1
+wget https://github.com/justadudewhohacks/face-api.js/raw/master/weights/face_landmark_68_model-shard1
+wget https://raw.githubusercontent.com/justadudewhohacks/face-api.js/master/weights/face_landmark_68_model-weights_manifest.json
+wget https://raw.githubusercontent.com/justadudewhohacks/face-api.js/master/weights/face_recognition_model-weights_manifest.json
+wget https://github.com/justadudewhohacks/face-api.js/raw/master/weights/face_recognition_model-shard2
+wget https://github.com/justadudewhohacks/face-api.js/raw/master/weights/face_recognition_model-shard1
+wget https://github.com/justadudewhohacks/face-api.js/raw/master/weights/face_expression_model-shard1
+wget https://raw.githubusercontent.com/justadudewhohacks/face-api.js/master/weights/face_expression_model-weights_manifest.json

--- a/src/utils/ground_truth.py
+++ b/src/utils/ground_truth.py
@@ -1,15 +1,15 @@
-import time
-from typing import List, Union, Dict
 import json
 import os
 import subprocess
 import threading
+import time
+from typing import Dict, List, Union
 
 import numpy as np
 import requests
-from PIL import Image
-from moviepy.editor import VideoFileClip
 from alive_progress import alive_bar
+from moviepy.editor import VideoFileClip
+from PIL import Image
 
 
 class FaceAPIThread(threading.Thread):
@@ -60,7 +60,11 @@ def experiment_ground_truth(video_file: str) -> None:
     video = VideoFileClip(video_file)
     port = 6060 + int(os.path.basename(video_file)[:3])
     emotions = _get_emotions(video, port)
-    destination = os.path.join("data", "ground_truth", f"{os.path.basename(video_file).split('.')[0]}_emotions.json")
+    destination = os.path.join(
+        "data",
+        "ground_truth",
+        f"{os.path.basename(video_file).split('.')[0]}_emotions.json",
+    )
     with open(destination, "w") as dest_file:
         json.dump(emotions, dest_file)
 
@@ -86,20 +90,18 @@ def _get_emotions(
     this_second = 0
     this_second_values = []
     with alive_bar(
-        int(video.fps * video.duration) // 30 + 1, title="Frame", force_tty=True
+        int(video.fps * video.duration) // 30 + 1,
+        title="Frame",
+        force_tty=True,
     ) as bar:
         for frame in frames:
             if counter // fps > this_second:
-                emotion_list.append(
-                    [str(counter / fps), this_second_values]
-                )
+                emotion_list.append([str(counter / fps), this_second_values])
                 this_second += 1
                 this_second_values = []
             if counter % 30 == 0:
                 if frame.shape[0] == 1080:
-                    frame = (
-                        frame.reshape((540, 2, 960, 2, 3)).max(3).max(1)
-                    )
+                    frame = frame.reshape((540, 2, 960, 2, 3)).max(3).max(1)
                 else:
                     image = Image.fromarray(np.uint8(frame), "RGB")
                     image = image.resize((960, 540))

--- a/src/utils/ground_truth.py
+++ b/src/utils/ground_truth.py
@@ -65,6 +65,9 @@ def experiment_ground_truth(video_file: str) -> None:
         "ground_truth",
         f"{os.path.basename(video_file).split('.')[0]}_emotions.json",
     )
+    print(
+        f"Running face-api.js to get ground truth for experiment {port-6060}."
+    )
     with open(destination, "w") as dest_file:
         json.dump(emotions, dest_file)
 

--- a/src/utils/ground_truth.py
+++ b/src/utils/ground_truth.py
@@ -59,14 +59,14 @@ def experiment_ground_truth(video_file: str) -> None:
     """
     video = VideoFileClip(video_file)
     port = 6060 + int(os.path.basename(video_file)[:3])
+    print(
+        f"Running face-api.js to get ground truth for experiment {port-6060}."
+    )
     emotions = _get_emotions(video, port)
     destination = os.path.join(
         "data",
         "ground_truth",
         f"{os.path.basename(video_file).split('.')[0]}_emotions.json",
-    )
-    print(
-        f"Running face-api.js to get ground truth for experiment {port-6060}."
     )
     with open(destination, "w") as dest_file:
         json.dump(emotions, dest_file)

--- a/src/utils/ground_truth.py
+++ b/src/utils/ground_truth.py
@@ -1,0 +1,127 @@
+import time
+from typing import List, Union, Dict
+import json
+import os
+import subprocess
+import threading
+
+import numpy as np
+import requests
+from PIL import Image
+from moviepy.editor import VideoFileClip
+from alive_progress import alive_bar
+
+
+class FaceAPIThread(threading.Thread):
+    """
+    Thread that runs face-api.js as a background server.
+    """
+
+    def __init__(self, port: int, logging: bool = False) -> None:
+        """
+        Create a thread that runs face-api.js
+
+        :param port: The port to start the API on.
+        """
+        super().__init__()
+        self.port = port
+        self.api = None
+        self.logging = logging
+
+    def run(self) -> None:
+        """
+        Thread run function that starts a subprocess with face-api.js
+        that listens on localhost:self.port/emotions.
+
+        """
+        env = os.environ.copy()
+        env["PORT"] = f"{self.port}"
+        self.api = subprocess.Popen(
+            ["npm", "run", "dev"],
+            cwd="src/utils/faceapi",
+            stdout=subprocess.DEVNULL if not self.logging else None,
+            env=env,
+        )
+
+    def stop(self):
+        """
+        Stop function that stops the subprocess and the API.
+        """
+        self.api.kill()
+
+
+def experiment_ground_truth(video_file: str) -> None:
+    """
+    Main function that creates ground truth for the experiments
+    using face expression emotions from face-api.js.
+
+    :param video_file: The video_file to compute the emotions for.
+    """
+    video = VideoFileClip(video_file)
+    port = 6060 + int(os.path.basename(video_file)[:3])
+    emotions = _get_emotions(video, port)
+    destination = os.path.join("data", "ground_truth", f"{os.path.basename(video_file).split('.')[0]}_emotions.json")
+    with open(destination, "w") as dest_file:
+        json.dump(emotions, dest_file)
+
+
+def _get_emotions(
+    video: VideoFileClip, port: int
+) -> List[List[Union[str, Dict[str, float]]]]:
+    """
+    Get emotions for timestamps in the video.
+
+    :param video: The video file to get the emotions for.
+    :return: Emotions list in the format needed for the API.
+    """
+
+    # Start the API for emotions prediction
+    api = FaceAPIThread(port)
+    api.start()
+    time.sleep(30)  # Give the API enough time to start
+    counter = 0
+    frames = video.iter_frames()
+    emotion_list = []
+    fps = 30
+    this_second = 0
+    this_second_values = []
+    with alive_bar(
+        int(video.fps * video.duration) // 30 + 1, title="Frame", force_tty=True
+    ) as bar:
+        for frame in frames:
+            if counter // fps > this_second:
+                emotion_list.append(
+                    [str(counter / fps), this_second_values]
+                )
+                this_second += 1
+                this_second_values = []
+            if counter % 30 == 0:
+                if frame.shape[0] == 1080:
+                    frame = (
+                        frame.reshape((540, 2, 960, 2, 3)).max(3).max(1)
+                    )
+                else:
+                    image = Image.fromarray(np.uint8(frame), "RGB")
+                    image = image.resize((960, 540))
+                    frame = np.array(image)
+                payload = json.dumps({"image": frame.tolist()})
+                headers = {
+                    "Content-type": "application/json",
+                    "Accept": "text/plain",
+                }
+                response = requests.post(
+                    f"http://localhost:{port}/emotions",
+                    data=payload,
+                    headers=headers,
+                )
+                assert response.status_code == 200
+                emotions = json.loads(response.content)["message"]
+                if isinstance(emotions, dict):
+                    for key, value in emotions.items():
+                        emotions[key] = f"{value:.5f}"
+                this_second_values.append(emotions)
+                bar()
+            counter += 1
+    api.stop()
+    api.join()
+    return emotion_list

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,0 +1,61 @@
+""" Implement interesting metrics to use them later. """
+
+import numpy as np
+from sklearn.metrics import (
+    accuracy_score,
+    confusion_matrix,
+    precision_score,
+    recall_score,
+)
+
+
+def accuracy(labels: np.ndarray, prediction: np.ndarray, **kwargs) -> float:
+    """
+    Compute the accuracy of predictions.
+
+    :param labels: Labels array.
+    :param prediction: Predicitions array from classifier.
+    :param kwargs: Additional kwargs.
+    :return: Accuracy
+    """
+    return accuracy_score(labels, prediction)
+
+
+def per_class_accuracy(
+    labels: np.ndarray, prediction: np.ndarray, **kwargs
+) -> float:
+    """
+    Compute the average per class accuracy of predictions.
+
+    :param labels: Labels array.
+    :param prediction: Predicitions array from classifier.
+    :param kwargs: Additional kwargs.
+    :return: Per class accuracy average
+    """
+    matrix = confusion_matrix(labels, prediction)
+    per_class_accs = matrix.diagonal() / matrix.sum(axis=1)
+    return np.mean(per_class_accs)
+
+
+def precision(labels: np.ndarray, prediction: np.ndarray, **kwargs) -> float:
+    """
+    Compute the precision of predictions.
+
+    :param labels: Labels array.
+    :param prediction: Predicitions array from classifier.
+    :param kwargs: Additional kwargs.
+    :return: Precision
+    """
+    return precision_score(labels, prediction, average="macro")
+
+
+def recall(labels: np.ndarray, prediction: np.ndarray, **kwargs) -> float:
+    """
+    Compute the recall of predictions.
+
+    :param labels: Labels array.
+    :param prediction: Predicitions array from classifier.
+    :param kwargs: Additional kwargs.
+    :return: Recall
+    """
+    return recall_score(labels, prediction, average="macro")


### PR DESCRIPTION
This branch implements different plant classifiers that use the PlantSpikerBox data to classify emotions.

Steps to implement:
- [ ] Data reading
- [ ] Data Preprocessing
- [ ] MFCC
- [ ] Cross Validation Experiment
- [ ] Base Classifier
- [ ] Dense Classifier
- [ ] LSTM Classifier
- [ ] MFCC + CNN Classifier
- [ ] Grid Search for parameters
- [ ] Tests